### PR TITLE
feat(automation): local OCR token optimization + fix automation-core tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,5 @@ android/
 ios/
 .bundle/
 GoogleService-Info.plist
-packages/rust-core/target/debug/
-packages/rust-core/target/tmp/
-packages/rust-core/target/release/
+packages/rust-core/target/
 packages/rust-core/*.png

--- a/.kiro/specs/ai-script-builder/tasks.md
+++ b/.kiro/specs/ai-script-builder/tasks.md
@@ -238,25 +238,25 @@
   - Display playback errors with edit option
   - _Requirements: 7.1, 7.4, 7.5, 7.6_
 
-- [~] 14.2 Create Playback Service
+- [x] 14.2 Create Playback Service
   - Create `packages/desktop/src/services/playbackService.ts`
   - Implement startPlayback, stopPlayback, togglePause
   - Implement progress event subscription
   - Connect to IPC bridge for playback control
   - _Requirements: 7.5_
 
-- [~] 14.3 Update Script Storage Service for AI metadata
+- [x] 14.3 Update Script Storage Service for AI metadata
   - Modify `packages/desktop/src/services/scriptStorageService.ts`
   - Add source='ai_generated' to saved scripts
   - Add target_os to metadata
   - Add generated_at timestamp
   - _Requirements: 7.3, 8.6_
 
-- [~] 14.4 Write property test for Save and Play Button State
+- [x] 14.4 Write property test for Save and Play Button State
   - **Property 11: Save and Play Button State**
   - **Validates: Requirements 7.1, 7.4**
 
-- [~] 14.5 Write property test for AI Script Metadata Consistency
+- [x] 14.5 Write property test for AI Script Metadata Consistency
   - **Property 12: AI Script Metadata Consistency**
   - **Validates: Requirements 7.3, 8.6**
 
@@ -286,11 +286,11 @@
   - Display target OS for AI scripts
   - _Requirements: 9.2, 9.5_
 
-- [~] 16.4 Write property test for Script List Completeness
+- [x] 16.4 Write property test for Script List Completeness
   - **Property 15: Script List Completeness**
   - **Validates: Requirements 9.1, 9.2, 10.2**
 
-- [~] 16.5 Write property test for Script Filter Correctness
+- [x] 16.5 Write property test for Script Filter Correctness
   - **Property 16: Script Filter Correctness**
   - **Validates: Requirements 9.4**
 
@@ -310,7 +310,7 @@
   - Test playback controls work with AI scripts
   - _Requirements: 9.3_
 
-- [~] 17.3 Write property test for AI Script Playback Compatibility
+- [x] 17.3 Write property test for AI Script Playback Compatibility
   - **Property 17: AI Script Playback Compatibility**
   - **Validates: Requirements 9.3**
 
@@ -343,7 +343,7 @@
   - Handle save and update script list
   - _Requirements: 10.3, 10.6_
 
-- [~] 18.5 Write property test for Unified Editor Consistency
+- [-] 18.5 Write property test for Unified Editor Consistency
   - **Property 18: Unified Editor Consistency**
   - **Validates: Requirements 10.3, 10.6**
 

--- a/.kiro/specs/ai-vision-capture/design.md
+++ b/.kiro/specs/ai-vision-capture/design.md
@@ -13,6 +13,29 @@ Tính năng bao gồm:
 - AI service integration để phân tích ảnh và trả về tọa độ
 - Hybrid playback logic cho cả Static và Dynamic mode
 
+### Token Optimization: Local OCR Fast Path
+
+Để tiết kiệm token (và hoạt động offline), `AIVisionService.analyze()` thử một
+bước **OCR cục bộ bằng Tesseract trước khi gọi LLM**:
+
+1. Nếu prompt chứa một text target cụ thể (ví dụ nhãn trong dấu ngoặc kép:
+   `Find the "Submit" button`), service trích xuất chuỗi `Submit`.
+2. Chạy OCR cục bộ (pytesseract) trên screenshot (đã crop theo ROI nếu có) để
+   định vị text đó. Bước này **tốn 0 token và không cần mạng**.
+3. Chỉ khi OCR cục bộ không tìm thấy với độ tin cậy đủ cao (kết hợp confidence
+   của OCR và độ khớp text), service mới fallback sang LLM (Gemini Vision).
+
+Quy tắc an toàn:
+- Bỏ qua OCR khi request có `reference_images` (ngụ ý so khớp hình ảnh, không
+  phải text).
+- pytesseract/binary `tesseract` là **optional**: nếu thiếu, `is_available()`
+  trả về False và service tự động dùng LLM (degrade gracefully).
+- Matcher cố tình bảo thủ (exact/whole-word/substring) để không click nhầm khi
+  khớp gần đúng — trường hợp mơ hồ luôn nhường cho LLM.
+
+Telemetry: `AIVisionService.local_ocr_hits` và `.llm_calls` cho phép định lượng
+lượng token tiết kiệm được. Module: `python-core/src/vision/local_ocr_service.py`.
+
 ## Architecture
 
 ### System Architecture

--- a/.kiro/specs/local-ocr-token-optimization/design.md
+++ b/.kiro/specs/local-ocr-token-optimization/design.md
@@ -1,0 +1,88 @@
+# Design Document: Local OCR Token Optimization
+
+## Overview
+
+Thêm một bước OCR cục bộ (Tesseract) làm fast-path trước khi gọi Vision LLM
+trong `AIVisionService.analyze()`. Mục tiêu: 0 token cho các text target, hoạt
+động offline, và degrade gracefully khi không có OCR engine.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A[analyze request] --> B{has reference_images?}
+    B -- yes --> L[Call Vision LLM]
+    B -- no --> C{OCR engine available?}
+    C -- no --> L
+    C -- yes --> D[extract_query_from_prompt]
+    D -- no quoted target --> L
+    D -- Text_Target --> E[LocalOCRService.locate_text]
+    E --> F{Combined_Confidence >= threshold?}
+    F -- yes --> G[Return coords + ROI offset<br/>0 token, llm_calls unchanged<br/>local_ocr_hits++]
+    F -- no --> L
+    L --> H[Return coords<br/>llm_calls++]
+```
+
+## Components
+
+### `LocalOCRService` (`python-core/src/vision/local_ocr_service.py`)
+
+- `is_available() -> bool`: True chỉ khi `pytesseract` import được VÀ
+  `get_tesseract_version()` chạy được.
+- `extract_text_boxes(screenshot, lang=None) -> List[OCRMatch]`: chạy
+  `image_to_data` (Output.DICT), bỏ box rỗng/`conf < 0`, trả tâm box + confidence
+  chuẩn hóa [0..1].
+- `locate_text(screenshot, query, lang=None) -> LocalOCRResult`: chọn box có
+  `Match_Score × OCR_confidence` cao nhất; success chỉ khi ≥ `min_confidence`
+  (mặc định 0.5).
+- `extract_query_from_prompt(prompt) -> Optional[str]` (staticmethod): trích cụm
+  trong ngoặc; None nếu không có.
+- Helpers thuần: `normalize_text`, `text_match_score` (exact 1.0 / whole-word 0.9
+  / substring 0.75 / 0.0).
+
+### Tích hợp vào `AIVisionService`
+
+- `__init__(local_ocr=None, enable_local_ocr=True)`: inject được để test.
+- `analyze()`: sau khi crop ROI, gọi `_try_local_ocr(...)`; nếu trả response thì
+  `local_ocr_hits++` và return; ngược lại tiếp tục nhánh LLM với `llm_calls++`.
+- `_try_local_ocr(...) -> Optional[AIVisionResponse]`: kiểm tra availability →
+  trích query → `locate_text` → cộng ROI offset; mọi exception → None (Fallback).
+- `set_local_ocr_enabled(bool)`.
+
+## Correctness Properties (validated by tests)
+
+- **Property 1 — Local hit skips LLM**: hit cục bộ ⇒ `llm_calls == 0`,
+  `local_ocr_hits == 1`. *(Req 1.2, 6.1)*
+- **Property 2 — Miss falls back**: OCR miss ⇒ LLM được gọi, `llm_calls == 1`.
+  *(Req 1.3, 6.2)*
+- **Property 3 — Reference images bypass OCR**: có reference_images ⇒
+  `locate_text` không được gọi. *(Req 1.4)*
+- **Property 4 — Disabled ⇒ always LLM**: `set_local_ocr_enabled(False)` ⇒ luôn
+  LLM. *(Req 6.3)*
+- **Property 5 — ROI offset applied**: hit cục bộ trong ROI ⇒ tọa độ + offset.
+  *(Req 4.1)*
+- **Property 6 — Graceful degradation**: engine vắng ⇒ `is_available()==False`,
+  `analyze()` dùng LLM, không raise. *(Req 5)*
+- **Property 7 — Conservative match tiers**: exact/word/substring/none mapping
+  đúng; không fuzzy. *(Req 3)*
+- **Property 8 — Unicode target**: trích & khớp "Đăng nhập". *(Req 2.3)*
+
+## Error Handling
+
+- Thiếu engine / lỗi decode / lỗi `image_to_data` → trả `[]` hoặc
+  `LocalOCRResult(success=False)` → Fallback LLM. Không bao giờ raise ra ngoài
+  `analyze()`.
+
+## Token Cost Model
+
+| Trường hợp | LLM call | Token |
+|---|---|---|
+| Text target, OCR hit | 0 | 0 |
+| Text target, OCR miss | 1 | có |
+| Có reference_images | 1 | có |
+| OCR engine vắng | 1 | có |
+
+## Dependencies
+
+- `pytesseract` (optional, đã thêm vào `requirements.txt`).
+- Binary `tesseract` (macOS: `brew install tesseract`).

--- a/.kiro/specs/local-ocr-token-optimization/requirements.md
+++ b/.kiro/specs/local-ocr-token-optimization/requirements.md
@@ -1,0 +1,117 @@
+# Requirements Document: Local OCR Token Optimization
+
+## Introduction
+
+Tính năng **Local OCR Token Optimization** giảm chi phí token và cho phép hoạt
+động offline cho AI Vision Capture bằng cách thêm một bước **OCR cục bộ
+(Tesseract)** chạy TRƯỚC khi gọi Vision LLM (Gemini).
+
+Phần lớn mục tiêu automation thực tế là nhãn văn bản ("Submit", "Login",
+"Đăng nhập"...). Với các mục tiêu này, một lượt OCR cục bộ có thể định vị phần
+tử với **0 token và không cần mạng**. LLM (tốn token) chỉ được gọi khi OCR cục
+bộ không tìm thấy với độ tin cậy đủ cao.
+
+Tính năng này bổ sung cho cơ chế Static/Dynamic Mode hiện có của
+[ai-vision-capture](../ai-vision-capture/requirements.md): nó tối ưu chính
+nhánh Dynamic (gọi AI khi playback) và bất kỳ lệnh `analyze()` nào có mục tiêu
+là văn bản.
+
+## Glossary
+
+- **Local_OCR**: Lượt nhận dạng văn bản chạy cục bộ bằng Tesseract (qua
+  `pytesseract`), không gọi mạng, không tốn token.
+- **OCR_Engine**: Binary `tesseract` + binding `pytesseract`. Cả hai là tùy
+  chọn (optional).
+- **Text_Target**: Chuỗi văn bản cụ thể trích từ prompt (ví dụ phần trong dấu
+  ngoặc kép) mà người dùng muốn định vị.
+- **Match_Score**: Điểm khớp văn bản [0..1] giữa Text_Target và một text box do
+  OCR phát hiện (exact / whole-word / substring).
+- **Combined_Confidence**: `Match_Score × OCR_confidence`, ngưỡng quyết định
+  chấp nhận hit cục bộ hay fallback LLM.
+- **Fallback**: Hành vi chuyển sang gọi Vision LLM khi OCR cục bộ không đủ tin cậy.
+- **Graceful_Degradation**: Khi OCR_Engine không khả dụng, hệ thống tự động dùng
+  LLM mà không lỗi.
+- **Telemetry**: Bộ đếm `local_ocr_hits` / `llm_calls` để định lượng token tiết kiệm.
+
+## Requirements
+
+### Requirement 1 — Ưu tiên OCR cục bộ trước LLM
+
+**User Story:** As an automation author, I want text targets located locally
+first, so that I do not spend LLM tokens on simple labels.
+
+#### Acceptance Criteria
+
+1. WHEN `analyze()` được gọi AND prompt chứa một Text_Target AND OCR_Engine khả
+   dụng THEN hệ thống PHẢI thử Local_OCR trước khi gọi LLM.
+2. IF Local_OCR trả về một hit với Combined_Confidence ≥ ngưỡng THEN hệ thống
+   PHẢI trả kết quả đó VÀ KHÔNG được gọi LLM (0 token).
+3. IF Local_OCR không tìm thấy hoặc Combined_Confidence < ngưỡng THEN hệ thống
+   PHẢI Fallback sang LLM.
+4. WHEN request có `reference_images` THEN hệ thống PHẢI bỏ qua Local_OCR (so
+   khớp hình ảnh thuộc về LLM, không phải văn bản).
+
+### Requirement 2 — Trích xuất Text_Target từ prompt
+
+**User Story:** As a user, I want quoted text in my prompt treated as the target,
+so that "Find the \"Submit\" button" locates `Submit`.
+
+#### Acceptance Criteria
+
+1. WHEN prompt chứa một cụm trong dấu ngoặc kép/đơn/thông minh THEN hệ thống PHẢI
+   dùng cụm đó làm Text_Target.
+2. IF prompt KHÔNG chứa cụm được trích rõ ràng THEN hệ thống PHẢI trả về None
+   (không Text_Target) VÀ để LLM xử lý.
+3. Text_Target PHẢI hỗ trợ Unicode (ví dụ tiếng Việt "Đăng nhập").
+
+### Requirement 3 — Khớp văn bản bảo thủ (an toàn)
+
+**User Story:** As a user, I want the matcher to avoid clicking the wrong control,
+so that near-misses defer to the LLM instead of acting incorrectly.
+
+#### Acceptance Criteria
+
+1. Match_Score PHẢI = 1.0 khi text khớp chính xác (sau khi chuẩn hóa
+   chữ thường + bỏ dấu câu bao quanh + gộp khoảng trắng).
+2. Match_Score PHẢI = 0.9 khi Text_Target xuất hiện như một từ độc lập trong text box.
+3. Match_Score PHẢI = 0.75 khi là substring có nghĩa (độ dài ≥ 3) nhưng không
+   phải từ độc lập.
+4. Match_Score PHẢI = 0.0 khi không khớp; KHÔNG dùng fuzzy edit-distance để
+   tránh khớp nhầm.
+5. WHEN nhiều text box khớp THEN hệ thống PHẢI chọn box có Combined_Confidence cao nhất.
+
+### Requirement 4 — Tọa độ & ROI nhất quán
+
+**User Story:** As a user, I want local hits to return the same coordinate space
+as LLM hits, so that ROI cropping behaves identically.
+
+#### Acceptance Criteria
+
+1. WHEN ROI được dùng THEN tọa độ hit cục bộ PHẢI được cộng offset ROI để trở về
+   không gian toàn màn hình (giống nhánh LLM).
+2. Tọa độ trả về PHẢI là tâm (center) của text box, là số nguyên.
+
+### Requirement 5 — Degrade gracefully (optional dependency)
+
+**User Story:** As an operator, I want automation to keep working when Tesseract
+is absent, so that the feature is never a hard dependency.
+
+#### Acceptance Criteria
+
+1. IF `pytesseract` không import được OR binary `tesseract` không chạy được THEN
+   `is_available()` PHẢI trả về False.
+2. WHEN OCR_Engine không khả dụng THEN `analyze()` PHẢI tự dùng LLM mà KHÔNG raise.
+3. Bất kỳ lỗi nào trong lượt OCR PHẢI được nuốt và chuyển thành Fallback, KHÔNG
+   làm hỏng `analyze()`.
+
+### Requirement 6 — Telemetry tiết kiệm token
+
+**User Story:** As a maintainer, I want to quantify savings, so that I can prove
+the optimization works.
+
+#### Acceptance Criteria
+
+1. Hệ thống PHẢI tăng `local_ocr_hits` mỗi khi một hit cục bộ thay cho một lệnh LLM.
+2. Hệ thống PHẢI tăng `llm_calls` mỗi khi thực sự gọi LLM.
+3. Có thể bật/tắt nhánh OCR qua `set_local_ocr_enabled(bool)`; khi tắt, hệ thống
+   PHẢI luôn dùng LLM.

--- a/.kiro/specs/local-ocr-token-optimization/tasks.md
+++ b/.kiro/specs/local-ocr-token-optimization/tasks.md
@@ -1,0 +1,56 @@
+# Implementation Plan: Local OCR Token Optimization
+
+- [x] 1. Create `LocalOCRService` module
+  - [x] 1.1 Optional dependency probing for `pytesseract` (no hard import failure)
+    - `_probe_pytesseract()` returns module or None
+    - _Requirements: 5.1, 5.2_
+  - [x] 1.2 Data classes `OCRMatch`, `LocalOCRResult`
+    - _Requirements: 4.2_
+  - [x] 1.3 Pure helpers `normalize_text`, `text_match_score`
+    - Tiers: exact 1.0 / whole-word 0.9 / substring 0.75 / 0.0; no fuzzy
+    - _Requirements: 3.1, 3.2, 3.3, 3.4_
+  - [x] 1.4 `is_available()` (pytesseract + working binary)
+    - _Requirements: 5.1_
+  - [x] 1.5 `extract_text_boxes()` via `image_to_data`
+    - Skip empty text and conf < 0; normalize confidence to [0..1]
+    - _Requirements: 1.1_
+  - [x] 1.6 `locate_text()` picks max Combined_Confidence ≥ threshold
+    - _Requirements: 1.2, 3.5_
+  - [x] 1.7 `extract_query_from_prompt()` (quoted phrase, Unicode-safe)
+    - _Requirements: 2.1, 2.2, 2.3_
+
+- [x] 2. Integrate fast-path into `AIVisionService`
+  - [x] 2.1 `__init__(local_ocr, enable_local_ocr)` + `set_local_ocr_enabled()`
+    - _Requirements: 6.3_
+  - [x] 2.2 `_try_local_ocr()` helper (availability → query → locate → ROI offset)
+    - Swallow all exceptions → return None (Fallback)
+    - _Requirements: 1.1, 4.1, 5.3_
+  - [x] 2.3 Call OCR before LLM in `analyze()`; skip when reference_images present
+    - _Requirements: 1.1, 1.4_
+  - [x] 2.4 Telemetry counters `local_ocr_hits` / `llm_calls`
+    - _Requirements: 6.1, 6.2_
+
+- [x] 3. Export from package and document
+  - [x] 3.1 Update `vision/__init__.py` exports
+  - [x] 3.2 Add `pytesseract` (optional) to `requirements.txt`
+  - [x] 3.3 Document fast-path in `ai-vision-capture/design.md`
+
+- [x] 4. Tests (`vision/test_local_ocr_service.py`, 29 tests)
+  - [x] 4.1 normalize_text / text_match_score / extract_query_from_prompt
+    - **Property 7, 8** — _Requirements: 2, 3_
+  - [x] 4.2 Availability + graceful degradation (pytesseract/binary missing)
+    - **Property 6** — _Requirements: 5_
+  - [x] 4.3 locate_text with injected fake engine (hit/miss/best-of-many)
+    - _Requirements: 1.2, 3.5_
+  - [x] 4.4 AIVisionService integration: local hit skips LLM; miss falls back;
+        reference images bypass; disabled ⇒ LLM; ROI offset applied
+    - **Property 1, 2, 3, 4, 5** — _Requirements: 1, 4, 6_
+
+- [x] 5. End-to-end self-running verification on macOS
+  - [x] 5.1 Real Tesseract locate on a synthetic rendered label (0 token)
+  - [x] 5.2 Full automation loop demo: screenshot → OCR/scan text → build script
+        → execute (dry-run) → LLM-coordinate fallback path → token accounting
+    - See `python-core/examples/self_running_macos_demo.py`
+
+- [x] 6. Final Checkpoint — all OCR tests pass, no regressions
+  - 330 python tests green (incl. 29 new); 369 rust; 514 desktop services+utils

--- a/packages/desktop/src/__tests__/integration/SaveAndPlayFlow.test.tsx
+++ b/packages/desktop/src/__tests__/integration/SaveAndPlayFlow.test.tsx
@@ -5,17 +5,17 @@
  * Requirements: 7.1, 7.2, 7.3, 7.4, 7.5
  */
 
-import { ScriptData } from '../../types/aiScriptBuilder.types';
 import {
-  validateScriptName,
-  generateFilename,
   generateDefaultName,
+  generateFilename,
+  validateScriptName,
 } from '../../components/ScriptNameDialog';
 import {
   generateScriptPath,
   prepareScriptForSave,
 } from '../../services/scriptStorageService';
 import { validateScript } from '../../services/scriptValidationService';
+import { ScriptData } from '../../types/aiScriptBuilder.types';
 
 /**
  * Helper to create a valid AI-generated test script
@@ -231,6 +231,74 @@ describe('Save and Play Flow Integration Tests', () => {
 
       expect(prepared.metadata.screen_resolution).toEqual([1920, 1080]);
       expect(prepared.metadata.platform).toBe('windows');
+    });
+
+    /**
+     * Test: Metadata includes source='ai_generated'
+     * Requirements: 7.3
+     */
+    it('should add source=ai_generated to metadata', () => {
+      const script = createAIGeneratedScript();
+      const prepared = prepareScriptForSave(script, 'Test Script');
+
+      expect(prepared.metadata.additional_data?.source).toBe('ai_generated');
+    });
+
+    /**
+     * Test: Metadata includes target_os when provided
+     * Requirements: 8.6
+     */
+    it('should add target_os to metadata when provided', () => {
+      const script = createAIGeneratedScript();
+      const prepared = prepareScriptForSave(script, 'Test Script', 'macos');
+
+      expect(prepared.metadata.additional_data?.target_os).toBe('macos');
+    });
+
+    /**
+     * Test: Metadata works without target_os
+     * Requirements: 8.6
+     */
+    it('should work without target_os when not provided', () => {
+      // Create a script without target_os in the original metadata
+      const script: ScriptData = {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration: 5000,
+          action_count: 2,
+          core_type: 'ai_generated',
+          platform: 'macos',
+        },
+        actions: [
+          { type: 'mouse_click', timestamp: 0, x: 100, y: 200, button: 'left' },
+          { type: 'wait', timestamp: 1000 },
+        ],
+      };
+
+      const prepared = prepareScriptForSave(script, 'Test Script');
+
+      expect(prepared.metadata.additional_data?.source).toBe('ai_generated');
+      expect(prepared.metadata.additional_data?.generated_at).toBeDefined();
+      // target_os should not be present if not provided
+      expect(prepared.metadata.additional_data?.target_os).toBeUndefined();
+    });
+
+    /**
+     * Test: Metadata includes all target_os options
+     * Requirements: 8.6
+     */
+    it('should support all target_os options', () => {
+      const script = createAIGeneratedScript();
+
+      const macOS = prepareScriptForSave(script, 'Test', 'macos');
+      expect(macOS.metadata.additional_data?.target_os).toBe('macos');
+
+      const windows = prepareScriptForSave(script, 'Test', 'windows');
+      expect(windows.metadata.additional_data?.target_os).toBe('windows');
+
+      const universal = prepareScriptForSave(script, 'Test', 'universal');
+      expect(universal.metadata.additional_data?.target_os).toBe('universal');
     });
   });
 

--- a/packages/desktop/src/components/__tests__/ScriptListCompleteness.property.test.tsx
+++ b/packages/desktop/src/components/__tests__/ScriptListCompleteness.property.test.tsx
@@ -1,0 +1,901 @@
+/**
+ * Property-Based Tests for Script List Completeness
+ * 
+ * Tests that the script list displays all scripts correctly with proper source indicators.
+ * For any combination of recorded and AI-generated scripts in storage, the script list
+ * should display all scripts with correct source type indicators.
+ * 
+ * **Feature: ai-script-builder, Property 15: Script List Completeness**
+ * **Validates: Requirements 9.1, 9.2, 10.2**
+ */
+
+import '@testing-library/jest-dom';
+import { cleanup, render, screen } from '@testing-library/react';
+import * as fc from 'fast-check';
+import {
+  ScriptFilter,
+  ScriptSource,
+  StoredScriptInfo,
+  TargetOS,
+} from '../../services/scriptStorageService';
+import { ScriptListTabContent } from '../tabs/ScriptListTabContent';
+
+// ============================================================================
+// Arbitraries (Generators)
+// ============================================================================
+
+/**
+ * Generate a valid script source type
+ */
+const scriptSourceArbitrary: fc.Arbitrary<ScriptSource> = fc.constantFrom(
+  'recorded',
+  'ai_generated'
+);
+
+/**
+ * Generate a valid target OS
+ */
+const targetOSArbitrary: fc.Arbitrary<TargetOS> = fc.constantFrom(
+  'macos',
+  'windows',
+  'universal'
+);
+
+/**
+ * Generate a valid script filename
+ */
+const scriptFilenameArbitrary = (source: ScriptSource): fc.Arbitrary<string> => {
+  if (source === 'ai_generated') {
+    return fc.tuple(
+      fc.string({ minLength: 5, maxLength: 30 }),
+      fc.integer({ min: 1000000000000, max: 9999999999999 })
+    ).map(([name, timestamp]) =>
+      `ai_script_${name.replace(/[^a-z0-9_-]/gi, '_')}_${timestamp}.json`
+    );
+  } else {
+    return fc.tuple(
+      fc.string({ minLength: 5, maxLength: 30 }),
+      fc.integer({ min: 1000000000000, max: 9999999999999 })
+    ).map(([name, timestamp]) =>
+      `recording_${name.replace(/[^a-z0-9_-]/gi, '_')}_${timestamp}.json`
+    );
+  }
+};
+
+/**
+ * Generate a valid script name (for AI-generated scripts)
+ */
+const scriptNameArbitrary: fc.Arbitrary<string> = fc.oneof(
+  fc.string({ minLength: 5, maxLength: 50 })
+    .filter(s => s.trim().length >= 5)
+    .map(s => s.replace(/[^a-zA-Z0-9_\-\s]/g, '')),
+  fc.constantFrom(
+    'Login Test',
+    'Navigation Flow',
+    'Form Submission',
+    'Data Entry Script',
+    'UI Automation Test'
+  )
+);
+
+/**
+ * Generate a recorded script info
+ */
+const recordedScriptArbitrary: fc.Arbitrary<StoredScriptInfo> = fc.record({
+  filename: scriptFilenameArbitrary('recorded'),
+  path: fc.string({ minLength: 10, maxLength: 100 })
+    .map(p => `/home/user/GeniusQA/recordings/${p}.json`),
+  createdAt: fc.integer({ min: new Date('2020-01-01').getTime(), max: new Date('2030-12-31').getTime() })
+    .map(timestamp => new Date(timestamp).toISOString()),
+  duration: fc.integer({ min: 1, max: 300 }),
+  actionCount: fc.integer({ min: 1, max: 100 }),
+  source: fc.constant('recorded' as const),
+});
+
+/**
+ * Generate an AI-generated script info
+ */
+const aiGeneratedScriptArbitrary: fc.Arbitrary<StoredScriptInfo> = fc.record({
+  filename: scriptFilenameArbitrary('ai_generated'),
+  path: fc.string({ minLength: 10, maxLength: 100 })
+    .map(p => `/home/user/GeniusQA/recordings/${p}.json`),
+  createdAt: fc.integer({ min: new Date('2020-01-01').getTime(), max: new Date('2030-12-31').getTime() })
+    .map(timestamp => new Date(timestamp).toISOString()),
+  duration: fc.integer({ min: 1, max: 300 }),
+  actionCount: fc.integer({ min: 1, max: 100 }),
+  source: fc.constant('ai_generated' as const),
+  targetOS: targetOSArbitrary,
+  scriptName: scriptNameArbitrary,
+});
+
+/**
+ * Generate a script info (either recorded or AI-generated)
+ */
+const scriptInfoArbitrary: fc.Arbitrary<StoredScriptInfo> = fc.oneof(
+  recordedScriptArbitrary,
+  aiGeneratedScriptArbitrary
+);
+
+/**
+ * Generate a combination of recorded and AI-generated scripts
+ */
+const scriptCombinationArbitrary: fc.Arbitrary<StoredScriptInfo[]> = fc.record({
+  recordedCount: fc.integer({ min: 0, max: 10 }),
+  aiGeneratedCount: fc.integer({ min: 0, max: 10 }),
+}).chain(({ recordedCount, aiGeneratedCount }) => {
+  return fc.tuple(
+    fc.array(recordedScriptArbitrary, { minLength: recordedCount, maxLength: recordedCount }),
+    fc.array(aiGeneratedScriptArbitrary, { minLength: aiGeneratedCount, maxLength: aiGeneratedCount })
+  ).map(([recorded, aiGenerated]) => [...recorded, ...aiGenerated]);
+});
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Renders ScriptListTabContent with given scripts
+ */
+const renderScriptList = (
+  scripts: StoredScriptInfo[],
+  filter: ScriptFilter = { source: 'all' }
+) => {
+  const mockOnFilterChange = jest.fn();
+  const mockOnScriptSelect = jest.fn();
+  const mockOnScriptDelete = jest.fn();
+
+  return render(
+    <ScriptListTabContent
+      scripts={scripts}
+      filter={filter}
+      onFilterChange={mockOnFilterChange}
+      onScriptSelect={mockOnScriptSelect}
+      onScriptDelete={mockOnScriptDelete}
+      loading={false}
+      selectedScriptPath={null}
+    />
+  );
+};
+
+/**
+ * Counts the number of script items displayed
+ */
+const countDisplayedScripts = (): number => {
+  const scriptListItems = screen.queryByTestId('script-list-items');
+  if (!scriptListItems) {
+    return 0;
+  }
+
+  // Count all script-list-item elements
+  const items = scriptListItems.querySelectorAll('.script-list-item');
+  return items.length;
+};
+
+/**
+ * Gets all displayed script items
+ */
+const getDisplayedScriptItems = (): HTMLElement[] => {
+  const scriptListItems = screen.queryByTestId('script-list-items');
+  if (!scriptListItems) {
+    return [];
+  }
+
+  return Array.from(scriptListItems.querySelectorAll('.script-list-item'));
+};
+
+/**
+ * Checks if a script item has the correct source badge
+ */
+const hasCorrectSourceBadge = (item: HTMLElement, expectedSource: ScriptSource): boolean => {
+  const sourceBadge = item.querySelector(`.script-badge.source-${expectedSource}`);
+  return sourceBadge !== null;
+};
+
+/**
+ * Checks if a script item has the correct OS badge (for AI-generated scripts)
+ */
+const hasCorrectOSBadge = (item: HTMLElement, expectedOS?: TargetOS): boolean => {
+  if (!expectedOS) {
+    // Should not have any OS badge
+    const osBadges = item.querySelectorAll('.script-badge[class*="os-"]');
+    return osBadges.length === 0;
+  }
+
+  const osBadge = item.querySelector(`.script-badge.os-${expectedOS}`);
+  return osBadge !== null;
+};
+
+/**
+ * Checks if a script item displays the correct filename
+ */
+const hasCorrectFilename = (item: HTMLElement, expectedFilename: string): boolean => {
+  const filenameElement = item.querySelector('.script-list-item-filename');
+  return filenameElement?.textContent === expectedFilename;
+};
+
+/**
+ * Verifies that all scripts are displayed with correct indicators
+ */
+const verifyAllScriptsDisplayed = (
+  scripts: StoredScriptInfo[],
+  displayedItems: HTMLElement[]
+): boolean => {
+  if (scripts.length !== displayedItems.length) {
+    return false;
+  }
+
+  // Create a map of filenames to scripts for easy lookup
+  const scriptMap = new Map(scripts.map(s => [s.filename, s]));
+
+  // Verify each displayed item
+  for (const item of displayedItems) {
+    const filenameElement = item.querySelector('.script-list-item-filename');
+    if (!filenameElement) {
+      return false;
+    }
+
+    const filename = filenameElement.textContent || '';
+    const script = scriptMap.get(filename);
+
+    if (!script) {
+      return false;
+    }
+
+    // Check source badge
+    if (!hasCorrectSourceBadge(item, script.source)) {
+      return false;
+    }
+
+    // Check OS badge (only for AI-generated scripts)
+    if (!hasCorrectOSBadge(item, script.targetOS)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+// ============================================================================
+// Property Tests
+// ============================================================================
+
+describe('Script List Completeness Property Tests', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  /**
+   * **Feature: ai-script-builder, Property 15: Script List Completeness**
+   * **Validates: Requirements 9.1, 9.2, 10.2**
+   * 
+   * For any combination of recorded and AI-generated scripts in storage,
+   * the script list SHALL display all scripts with correct source type indicators.
+   */
+  describe('Property 15: Script List Completeness', () => {
+    it('displays all scripts regardless of source type', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            cleanup();
+            renderScriptList(scripts);
+
+            if (scripts.length === 0) {
+              // Should show empty state
+              const emptyState = screen.queryByTestId('script-list-empty');
+              return emptyState !== null;
+            }
+
+            // Should display all scripts
+            const displayedCount = countDisplayedScripts();
+            return displayedCount === scripts.length;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('displays correct source badge for each script', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            cleanup();
+
+            if (scripts.length === 0) {
+              return true; // Skip empty case
+            }
+
+            renderScriptList(scripts);
+            const displayedItems = getDisplayedScriptItems();
+
+            // Verify each script has correct source badge
+            for (let i = 0; i < scripts.length; i++) {
+              const script = scripts[i];
+              const item = displayedItems[i];
+
+              if (!item) {
+                return false;
+              }
+
+              if (!hasCorrectSourceBadge(item, script.source)) {
+                return false;
+              }
+            }
+
+            return true;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('displays OS badge only for AI-generated scripts', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            cleanup();
+
+            if (scripts.length === 0) {
+              return true; // Skip empty case
+            }
+
+            renderScriptList(scripts);
+            const displayedItems = getDisplayedScriptItems();
+
+            // Verify OS badges
+            for (let i = 0; i < scripts.length; i++) {
+              const script = scripts[i];
+              const item = displayedItems[i];
+
+              if (!item) {
+                return false;
+              }
+
+              if (script.source === 'ai_generated') {
+                // Should have OS badge
+                if (!hasCorrectOSBadge(item, script.targetOS)) {
+                  return false;
+                }
+              } else {
+                // Should NOT have OS badge
+                if (!hasCorrectOSBadge(item, undefined)) {
+                  return false;
+                }
+              }
+            }
+
+            return true;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('displays all recorded scripts with recorded badge', () => {
+      fc.assert(
+        fc.property(
+          fc.array(recordedScriptArbitrary, { minLength: 1, maxLength: 20 }),
+          (scripts) => {
+            cleanup();
+            renderScriptList(scripts);
+
+            const displayedItems = getDisplayedScriptItems();
+
+            // All items should have recorded badge
+            return displayedItems.every(item =>
+              hasCorrectSourceBadge(item, 'recorded')
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('displays all AI-generated scripts with AI badge', () => {
+      fc.assert(
+        fc.property(
+          fc.array(aiGeneratedScriptArbitrary, { minLength: 1, maxLength: 20 }),
+          (scripts) => {
+            cleanup();
+            renderScriptList(scripts);
+
+            const displayedItems = getDisplayedScriptItems();
+
+            // All items should have AI-generated badge
+            return displayedItems.every(item =>
+              hasCorrectSourceBadge(item, 'ai_generated')
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('displays correct filename for each script', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            cleanup();
+
+            if (scripts.length === 0) {
+              return true; // Skip empty case
+            }
+
+            renderScriptList(scripts);
+            const displayedItems = getDisplayedScriptItems();
+
+            // Verify each script has correct filename
+            for (const script of scripts) {
+              const matchingItem = displayedItems.find(item =>
+                hasCorrectFilename(item, script.filename)
+              );
+
+              if (!matchingItem) {
+                return false;
+              }
+            }
+
+            return true;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('displays all scripts with complete metadata', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            cleanup();
+
+            if (scripts.length === 0) {
+              return true; // Skip empty case
+            }
+
+            renderScriptList(scripts);
+            const displayedItems = getDisplayedScriptItems();
+
+            return verifyAllScriptsDisplayed(scripts, displayedItems);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('maintains script order in display', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            cleanup();
+
+            if (scripts.length === 0) {
+              return true; // Skip empty case
+            }
+
+            renderScriptList(scripts);
+            const displayedItems = getDisplayedScriptItems();
+
+            // Verify order matches
+            for (let i = 0; i < scripts.length; i++) {
+              const script = scripts[i];
+              const item = displayedItems[i];
+
+              if (!item || !hasCorrectFilename(item, script.filename)) {
+                return false;
+              }
+            }
+
+            return true;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('displays mixed recorded and AI scripts correctly', () => {
+      fc.assert(
+        fc.property(
+          fc.tuple(
+            fc.array(recordedScriptArbitrary, { minLength: 1, maxLength: 5 }),
+            fc.array(aiGeneratedScriptArbitrary, { minLength: 1, maxLength: 5 })
+          ),
+          ([recorded, aiGenerated]) => {
+            cleanup();
+            const scripts = [...recorded, ...aiGenerated];
+            renderScriptList(scripts);
+
+            const displayedItems = getDisplayedScriptItems();
+
+            // Should display all scripts
+            if (displayedItems.length !== scripts.length) {
+              return false;
+            }
+
+            // Verify recorded scripts have recorded badge
+            const recordedItems = displayedItems.slice(0, recorded.length);
+            const allRecordedCorrect = recordedItems.every(item =>
+              hasCorrectSourceBadge(item, 'recorded')
+            );
+
+            // Verify AI scripts have AI badge and OS badge
+            const aiItems = displayedItems.slice(recorded.length);
+            const allAICorrect = aiItems.every((item, idx) =>
+              hasCorrectSourceBadge(item, 'ai_generated') &&
+              hasCorrectOSBadge(item, aiGenerated[idx].targetOS)
+            );
+
+            return allRecordedCorrect && allAICorrect;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('displays scripts with different target OS correctly', () => {
+      fc.assert(
+        fc.property(
+          fc.tuple(
+            aiGeneratedScriptArbitrary,
+            aiGeneratedScriptArbitrary,
+            aiGeneratedScriptArbitrary
+          ).map(([s1, s2, s3]) => [
+            { ...s1, targetOS: 'macos' as TargetOS },
+            { ...s2, targetOS: 'windows' as TargetOS },
+            { ...s3, targetOS: 'universal' as TargetOS },
+          ]),
+          (scripts) => {
+            cleanup();
+            renderScriptList(scripts);
+
+            const displayedItems = getDisplayedScriptItems();
+
+            // Verify each script has correct OS badge
+            return scripts.every((script, idx) => {
+              const item = displayedItems[idx];
+              return item && hasCorrectOSBadge(item, script.targetOS);
+            });
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('handles empty script list correctly', () => {
+      cleanup();
+      renderScriptList([]);
+
+      // Should show empty state
+      const emptyState = screen.queryByTestId('script-list-empty');
+      expect(emptyState).toBeInTheDocument();
+
+      // Should not show any script items
+      const displayedCount = countDisplayedScripts();
+      expect(displayedCount).toBe(0);
+    });
+
+    it('handles single script correctly', () => {
+      fc.assert(
+        fc.property(
+          scriptInfoArbitrary,
+          (script) => {
+            cleanup();
+            renderScriptList([script]);
+
+            const displayedCount = countDisplayedScripts();
+            if (displayedCount !== 1) {
+              return false;
+            }
+
+            const displayedItems = getDisplayedScriptItems();
+            const item = displayedItems[0];
+
+            return hasCorrectSourceBadge(item, script.source) &&
+              hasCorrectFilename(item, script.filename) &&
+              hasCorrectOSBadge(item, script.targetOS);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('handles large number of scripts correctly', () => {
+      fc.assert(
+        fc.property(
+          fc.array(scriptInfoArbitrary, { minLength: 50, maxLength: 100 }),
+          (scripts) => {
+            cleanup();
+            renderScriptList(scripts);
+
+            const displayedCount = countDisplayedScripts();
+            return displayedCount === scripts.length;
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('displays script name for AI-generated scripts', () => {
+      fc.assert(
+        fc.property(
+          fc.array(aiGeneratedScriptArbitrary, { minLength: 1, maxLength: 10 }),
+          (scripts) => {
+            cleanup();
+            renderScriptList(scripts);
+
+            const displayedItems = getDisplayedScriptItems();
+
+            // Verify each AI script shows its script name
+            return scripts.every((script, idx) => {
+              const item = displayedItems[idx];
+              if (!item) return false;
+
+              const scriptNameElement = item.querySelector('.script-list-item-name');
+              return scriptNameElement?.textContent === script.scriptName;
+            });
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('does not display script name for recorded scripts', () => {
+      fc.assert(
+        fc.property(
+          fc.array(recordedScriptArbitrary, { minLength: 1, maxLength: 10 }),
+          (scripts) => {
+            cleanup();
+            renderScriptList(scripts);
+
+            const displayedItems = getDisplayedScriptItems();
+
+            // Verify recorded scripts don't show script name
+            return displayedItems.every(item => {
+              const scriptNameElement = item.querySelector('.script-list-item-name');
+              return scriptNameElement === null || scriptNameElement.textContent === '';
+            });
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('displays action count for all scripts', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            cleanup();
+
+            if (scripts.length === 0) {
+              return true; // Skip empty case
+            }
+
+            renderScriptList(scripts);
+            const displayedItems = getDisplayedScriptItems();
+
+            // Verify each script shows action count
+            return scripts.every((script, idx) => {
+              const item = displayedItems[idx];
+              if (!item) return false;
+
+              const infoText = item.textContent || '';
+              return infoText.includes(`Actions: ${script.actionCount}`);
+            });
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('displays duration for all scripts', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            cleanup();
+
+            if (scripts.length === 0) {
+              return true; // Skip empty case
+            }
+
+            renderScriptList(scripts);
+            const displayedItems = getDisplayedScriptItems();
+
+            // Verify each script shows duration
+            return scripts.every((script, idx) => {
+              const item = displayedItems[idx];
+              if (!item) return false;
+
+              const infoText = item.textContent || '';
+              return infoText.includes('Duration:');
+            });
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('displays created date for all scripts', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            cleanup();
+
+            if (scripts.length === 0) {
+              return true; // Skip empty case
+            }
+
+            renderScriptList(scripts);
+            const displayedItems = getDisplayedScriptItems();
+
+            // Verify each script shows created date
+            return scripts.every((script, idx) => {
+              const item = displayedItems[idx];
+              if (!item) return false;
+
+              const infoText = item.textContent || '';
+              return infoText.includes('Created:');
+            });
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Edge cases and boundary conditions
+   */
+  describe('Edge Cases and Boundary Conditions', () => {
+    it('handles scripts with very long filenames', () => {
+      const longFilename = 'ai_script_' + 'a'.repeat(200) + '.json';
+      const script: StoredScriptInfo = {
+        filename: longFilename,
+        path: '/home/user/GeniusQA/recordings/' + longFilename,
+        createdAt: new Date().toISOString(),
+        duration: 10,
+        actionCount: 5,
+        source: 'ai_generated',
+        targetOS: 'macos',
+        scriptName: 'Test Script',
+      };
+
+      cleanup();
+      renderScriptList([script]);
+
+      const displayedCount = countDisplayedScripts();
+      expect(displayedCount).toBe(1);
+
+      const displayedItems = getDisplayedScriptItems();
+      expect(hasCorrectFilename(displayedItems[0], longFilename)).toBe(true);
+    });
+
+    it('handles scripts with special characters in names', () => {
+      const script: StoredScriptInfo = {
+        filename: 'ai_script_test-123_v2.0.json',
+        path: '/home/user/GeniusQA/recordings/ai_script_test-123_v2.0.json',
+        createdAt: new Date().toISOString(),
+        duration: 10,
+        actionCount: 5,
+        source: 'ai_generated',
+        targetOS: 'windows',
+        scriptName: 'Test Script (v2.0) - Final',
+      };
+
+      cleanup();
+      renderScriptList([script]);
+
+      const displayedCount = countDisplayedScripts();
+      expect(displayedCount).toBe(1);
+    });
+
+    it('handles scripts with zero duration', () => {
+      const script: StoredScriptInfo = {
+        filename: 'recording_instant.json',
+        path: '/home/user/GeniusQA/recordings/recording_instant.json',
+        createdAt: new Date().toISOString(),
+        duration: 0,
+        actionCount: 1,
+        source: 'recorded',
+      };
+
+      cleanup();
+      renderScriptList([script]);
+
+      const displayedCount = countDisplayedScripts();
+      expect(displayedCount).toBe(1);
+    });
+
+    it('handles scripts with zero actions', () => {
+      const script: StoredScriptInfo = {
+        filename: 'recording_empty.json',
+        path: '/home/user/GeniusQA/recordings/recording_empty.json',
+        createdAt: new Date().toISOString(),
+        duration: 0,
+        actionCount: 0,
+        source: 'recorded',
+      };
+
+      cleanup();
+      renderScriptList([script]);
+
+      const displayedCount = countDisplayedScripts();
+      expect(displayedCount).toBe(1);
+    });
+
+    it('handles scripts with very large action counts', () => {
+      const script: StoredScriptInfo = {
+        filename: 'ai_script_large.json',
+        path: '/home/user/GeniusQA/recordings/ai_script_large.json',
+        createdAt: new Date().toISOString(),
+        duration: 3600,
+        actionCount: 10000,
+        source: 'ai_generated',
+        targetOS: 'universal',
+        scriptName: 'Large Test Script',
+      };
+
+      cleanup();
+      renderScriptList([script]);
+
+      const displayedCount = countDisplayedScripts();
+      expect(displayedCount).toBe(1);
+
+      const displayedItems = getDisplayedScriptItems();
+      const infoText = displayedItems[0].textContent || '';
+      expect(infoText).toContain('Actions: 10000');
+    });
+
+    it('handles all three target OS types in one list', () => {
+      const scripts: StoredScriptInfo[] = [
+        {
+          filename: 'ai_script_macos.json',
+          path: '/home/user/GeniusQA/recordings/ai_script_macos.json',
+          createdAt: new Date().toISOString(),
+          duration: 10,
+          actionCount: 5,
+          source: 'ai_generated',
+          targetOS: 'macos',
+          scriptName: 'macOS Script',
+        },
+        {
+          filename: 'ai_script_windows.json',
+          path: '/home/user/GeniusQA/recordings/ai_script_windows.json',
+          createdAt: new Date().toISOString(),
+          duration: 10,
+          actionCount: 5,
+          source: 'ai_generated',
+          targetOS: 'windows',
+          scriptName: 'Windows Script',
+        },
+        {
+          filename: 'ai_script_universal.json',
+          path: '/home/user/GeniusQA/recordings/ai_script_universal.json',
+          createdAt: new Date().toISOString(),
+          duration: 10,
+          actionCount: 5,
+          source: 'ai_generated',
+          targetOS: 'universal',
+          scriptName: 'Universal Script',
+        },
+      ];
+
+      cleanup();
+      renderScriptList(scripts);
+
+      const displayedCount = countDisplayedScripts();
+      expect(displayedCount).toBe(3);
+
+      const displayedItems = getDisplayedScriptItems();
+      expect(hasCorrectOSBadge(displayedItems[0], 'macos')).toBe(true);
+      expect(hasCorrectOSBadge(displayedItems[1], 'windows')).toBe(true);
+      expect(hasCorrectOSBadge(displayedItems[2], 'universal')).toBe(true);
+    });
+  });
+});

--- a/packages/desktop/src/components/__tests__/ScriptPreview.property.test.tsx
+++ b/packages/desktop/src/components/__tests__/ScriptPreview.property.test.tsx
@@ -1,0 +1,732 @@
+/**
+ * Property-Based Tests for Script Preview - Save and Play Button State
+ * 
+ * Tests that the Save and Play buttons appear and behave correctly
+ * based on script state and validation status.
+ * 
+ * **Feature: ai-script-builder, Property 11: Save and Play Button State**
+ * **Validates: Requirements 7.1, 7.4**
+ */
+
+import '@testing-library/jest-dom';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import * as fc from 'fast-check';
+import {
+  Action,
+  ActionType,
+  ScriptData,
+  ScriptMetadata,
+  ValidationResult,
+} from '../../types/aiScriptBuilder.types';
+import { ScriptPreview } from '../ScriptPreview';
+
+// ============================================================================
+// Arbitraries (Generators)
+// ============================================================================
+
+/**
+ * Generate a valid action type
+ */
+const actionTypeArbitrary: fc.Arbitrary<ActionType> = fc.constantFrom(
+  'mouse_move',
+  'mouse_click',
+  'mouse_double_click',
+  'mouse_drag',
+  'mouse_scroll',
+  'key_press',
+  'key_release',
+  'key_type',
+  'screenshot',
+  'wait',
+  'custom'
+);
+
+/**
+ * Generate a valid mouse action
+ */
+const mouseActionArbitrary = (timestamp: number): fc.Arbitrary<Action> => {
+  return fc.oneof(
+    // Mouse move
+    fc.record({
+      type: fc.constant('mouse_move' as const),
+      timestamp: fc.constant(timestamp),
+      x: fc.integer({ min: 0, max: 1920 }),
+      y: fc.integer({ min: 0, max: 1080 }),
+    }),
+    // Mouse click
+    fc.record({
+      type: fc.constant('mouse_click' as const),
+      timestamp: fc.constant(timestamp),
+      x: fc.integer({ min: 0, max: 1920 }),
+      y: fc.integer({ min: 0, max: 1080 }),
+      button: fc.constantFrom('left' as const, 'right' as const, 'middle' as const),
+    }),
+    // Mouse double click
+    fc.record({
+      type: fc.constant('mouse_double_click' as const),
+      timestamp: fc.constant(timestamp),
+      x: fc.integer({ min: 0, max: 1920 }),
+      y: fc.integer({ min: 0, max: 1080 }),
+      button: fc.constantFrom('left' as const, 'right' as const, 'middle' as const),
+    })
+  );
+};
+
+/**
+ * Generate a valid keyboard action
+ */
+const keyboardActionArbitrary = (timestamp: number): fc.Arbitrary<Action> => {
+  return fc.oneof(
+    // Key press
+    fc.record({
+      type: fc.constant('key_press' as const),
+      timestamp: fc.constant(timestamp),
+      key: fc.constantFrom('a', 'b', 'c', 'enter', 'escape', 'tab', 'space'),
+      modifiers: fc.array(fc.constantFrom('ctrl', 'shift', 'alt', 'meta'), { maxLength: 2 }),
+    }),
+    // Key type
+    fc.record({
+      type: fc.constant('key_type' as const),
+      timestamp: fc.constant(timestamp),
+      text: fc.string({ minLength: 1, maxLength: 50 }),
+    })
+  );
+};
+
+/**
+ * Generate a valid action
+ */
+const actionArbitrary = (timestamp: number): fc.Arbitrary<Action> => {
+  return fc.oneof(
+    mouseActionArbitrary(timestamp),
+    keyboardActionArbitrary(timestamp),
+    // Wait action
+    fc.record({
+      type: fc.constant('wait' as const),
+      timestamp: fc.constant(timestamp),
+    })
+  );
+};
+
+/**
+ * Generate valid script metadata
+ */
+const scriptMetadataArbitrary = (actionCount: number, duration: number): fc.Arbitrary<ScriptMetadata> => {
+  return fc.record({
+    created_at: fc.date({ min: new Date('2020-01-01'), max: new Date('2030-12-31') })
+      .map(d => d.toISOString()),
+    duration: fc.constant(duration),
+    action_count: fc.constant(actionCount),
+    core_type: fc.constant('rust'),
+    platform: fc.constantFrom('macos', 'windows', 'universal'),
+  });
+};
+
+/**
+ * Generate a valid script with specified number of actions
+ */
+const validScriptArbitrary: fc.Arbitrary<ScriptData> = fc
+  .integer({ min: 1, max: 20 })
+  .chain(actionCount => {
+    // Generate timestamps in ascending order
+    const timestamps = Array.from({ length: actionCount }, (_, i) => i * 500);
+
+    // Generate actions with those timestamps
+    const actionsArb = fc.array(
+      fc.integer({ min: 0, max: actionCount - 1 }).chain(idx =>
+        actionArbitrary(timestamps[idx])
+      ),
+      { minLength: actionCount, maxLength: actionCount }
+    );
+
+    return actionsArb.map(actions => {
+      // Sort by timestamp to ensure order
+      actions.sort((a, b) => a.timestamp - b.timestamp);
+      const duration = actions.length > 0 ? actions[actions.length - 1].timestamp : 0;
+
+      return {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration,
+          action_count: actions.length,
+          core_type: 'rust',
+          platform: 'macos',
+        },
+        actions,
+      };
+    });
+  });
+
+/**
+ * Generate a valid validation result (no errors)
+ */
+const validValidationResultArbitrary: fc.Arbitrary<ValidationResult> = fc.constant({
+  valid: true,
+  errors: [],
+  warnings: [],
+});
+
+/**
+ * Generate an invalid validation result (with errors)
+ */
+const invalidValidationResultArbitrary: fc.Arbitrary<ValidationResult> = fc
+  .array(
+    fc.record({
+      field: fc.constantFrom('actions[0].x', 'actions[0].y', 'actions[1].key', 'metadata.duration'),
+      message: fc.constantFrom(
+        'X coordinate out of bounds',
+        'Y coordinate out of bounds',
+        'Invalid key code',
+        'Duration mismatch'
+      ),
+      actionIndex: fc.option(fc.integer({ min: 0, max: 10 }), { nil: undefined }),
+    }),
+    { minLength: 1, maxLength: 5 }
+  )
+  .map(errors => ({
+    valid: false,
+    errors,
+    warnings: [],
+  }));
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Render ScriptPreview with given props
+ */
+const renderScriptPreview = (
+  script: ScriptData | null,
+  validationResult: ValidationResult,
+  isSaved: boolean = false,
+  onPlay?: (script: ScriptData) => void
+) => {
+  return render(
+    <ScriptPreview
+      script={script}
+      onEdit={jest.fn()}
+      onSave={jest.fn()}
+      onDiscard={jest.fn()}
+      onPlay={onPlay}
+      validationResult={validationResult}
+      isSaved={isSaved}
+      isPlaying={false}
+    />
+  );
+};
+
+/**
+ * Check if Save button is visible and enabled
+ */
+const isSaveButtonVisibleAndEnabled = (): boolean => {
+  const saveButton = screen.queryByText(/💾\s*Save Script/i);
+  return saveButton !== null && !saveButton.hasAttribute('disabled');
+};
+
+/**
+ * Check if Save button shows "Saved" state
+ */
+const isSaveButtonInSavedState = (): boolean => {
+  const savedButton = screen.queryByText(/💾\s*Saved/i);
+  return savedButton !== null && savedButton.hasAttribute('disabled');
+};
+
+/**
+ * Check if Play button is visible
+ */
+const isPlayButtonVisible = (): boolean => {
+  const playButton = screen.queryByTestId('script-play-button');
+  return playButton !== null;
+};
+
+/**
+ * Check if Play button is enabled
+ */
+const isPlayButtonEnabled = (): boolean => {
+  const playButton = screen.queryByTestId('script-play-button');
+  return playButton !== null && !playButton.hasAttribute('disabled');
+};
+
+// ============================================================================
+// Property Tests
+// ============================================================================
+
+describe('ScriptPreview Property Tests - Save and Play Button State', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  /**
+   * **Feature: ai-script-builder, Property 11: Save and Play Button State**
+   * **Validates: Requirements 7.1, 7.4**
+   * 
+   * For any valid generated script, the Save button SHALL be visible.
+   * After successful save, the Play button SHALL become visible.
+   */
+  describe('Property 11: Save and Play Button State', () => {
+    it('Save button is visible for any valid generated script', () => {
+      fc.assert(
+        fc.property(
+          validScriptArbitrary,
+          validValidationResultArbitrary,
+          (script, validationResult) => {
+            cleanup();
+            renderScriptPreview(script, validationResult, false);
+
+            // Save button should be visible and enabled
+            return isSaveButtonVisibleAndEnabled();
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('Save button is disabled when script is already saved', () => {
+      fc.assert(
+        fc.property(
+          validScriptArbitrary,
+          validValidationResultArbitrary,
+          (script, validationResult) => {
+            cleanup();
+            renderScriptPreview(script, validationResult, true);
+
+            // Save button should show "Saved" and be disabled
+            return isSaveButtonInSavedState();
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('Save button is disabled when script has validation errors', () => {
+      fc.assert(
+        fc.property(
+          validScriptArbitrary,
+          invalidValidationResultArbitrary,
+          (script, validationResult) => {
+            cleanup();
+            renderScriptPreview(script, validationResult, false);
+
+            const saveButton = screen.queryByText(/💾\s*Save Script/i);
+            return saveButton !== null && saveButton.hasAttribute('disabled');
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('Play button is NOT visible when script is not saved', () => {
+      fc.assert(
+        fc.property(
+          validScriptArbitrary,
+          validValidationResultArbitrary,
+          (script, validationResult) => {
+            cleanup();
+            const mockOnPlay = jest.fn();
+            renderScriptPreview(script, validationResult, false, mockOnPlay);
+
+            // Play button should NOT be visible
+            return !isPlayButtonVisible();
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('Play button IS visible when script is saved and onPlay is provided', () => {
+      fc.assert(
+        fc.property(
+          validScriptArbitrary,
+          validValidationResultArbitrary,
+          (script, validationResult) => {
+            cleanup();
+            const mockOnPlay = jest.fn();
+            renderScriptPreview(script, validationResult, true, mockOnPlay);
+
+            // Play button should be visible
+            return isPlayButtonVisible();
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('Play button is NOT visible when onPlay callback is not provided', () => {
+      fc.assert(
+        fc.property(
+          validScriptArbitrary,
+          validValidationResultArbitrary,
+          (script, validationResult) => {
+            cleanup();
+            renderScriptPreview(script, validationResult, true, undefined);
+
+            // Play button should NOT be visible
+            return !isPlayButtonVisible();
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('Play button is enabled when script is saved and valid', () => {
+      fc.assert(
+        fc.property(
+          validScriptArbitrary,
+          validValidationResultArbitrary,
+          (script, validationResult) => {
+            cleanup();
+            const mockOnPlay = jest.fn();
+            renderScriptPreview(script, validationResult, true, mockOnPlay);
+
+            // Play button should be visible and enabled
+            return isPlayButtonVisible() && isPlayButtonEnabled();
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('Play button is disabled when script has validation errors', () => {
+      fc.assert(
+        fc.property(
+          validScriptArbitrary,
+          invalidValidationResultArbitrary,
+          (script, validationResult) => {
+            cleanup();
+            const mockOnPlay = jest.fn();
+            renderScriptPreview(script, validationResult, true, mockOnPlay);
+
+            const playButton = screen.queryByTestId('script-play-button');
+            return playButton !== null && playButton.hasAttribute('disabled');
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('clicking Play button calls onPlay callback with script', () => {
+      fc.assert(
+        fc.property(
+          validScriptArbitrary,
+          validValidationResultArbitrary,
+          (script, validationResult) => {
+            cleanup();
+            const mockOnPlay = jest.fn();
+            renderScriptPreview(script, validationResult, true, mockOnPlay);
+
+            const playButton = screen.getByTestId('script-play-button');
+            fireEvent.click(playButton);
+
+            // onPlay should be called with the script
+            return mockOnPlay.mock.calls.length === 1 &&
+              mockOnPlay.mock.calls[0][0] === script;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('Save button state transitions correctly: unsaved -> saved', () => {
+      fc.assert(
+        fc.property(
+          validScriptArbitrary,
+          validValidationResultArbitrary,
+          (script, validationResult) => {
+            cleanup();
+            const { rerender } = renderScriptPreview(script, validationResult, false);
+
+            // Initially, Save button should be enabled
+            const initialState = isSaveButtonVisibleAndEnabled();
+
+            // Re-render with isSaved=true
+            rerender(
+              <ScriptPreview
+                script={script}
+                onEdit={jest.fn()}
+                onSave={jest.fn()}
+                onDiscard={jest.fn()}
+                validationResult={validationResult}
+                isSaved={true}
+                isPlaying={false}
+              />
+            );
+
+            // Now Save button should show "Saved" and be disabled
+            const savedState = isSaveButtonInSavedState();
+
+            return initialState && savedState;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('Play button appears after save state transition', () => {
+      fc.assert(
+        fc.property(
+          validScriptArbitrary,
+          validValidationResultArbitrary,
+          (script, validationResult) => {
+            cleanup();
+            const mockOnPlay = jest.fn();
+            const { rerender } = renderScriptPreview(script, validationResult, false, mockOnPlay);
+
+            // Initially, Play button should NOT be visible
+            const initialPlayVisible = isPlayButtonVisible();
+
+            // Re-render with isSaved=true
+            rerender(
+              <ScriptPreview
+                script={script}
+                onEdit={jest.fn()}
+                onSave={jest.fn()}
+                onDiscard={jest.fn()}
+                onPlay={mockOnPlay}
+                validationResult={validationResult}
+                isSaved={true}
+                isPlaying={false}
+              />
+            );
+
+            // Now Play button should be visible
+            const finalPlayVisible = isPlayButtonVisible();
+
+            return !initialPlayVisible && finalPlayVisible;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('button states are consistent across different script sizes', () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 1, max: 50 }),
+          validValidationResultArbitrary,
+          fc.boolean(),
+          (actionCount, validationResult, isSaved) => {
+            cleanup();
+
+            // Generate script with specific action count
+            const timestamps = Array.from({ length: actionCount }, (_, i) => i * 100);
+            const actions: Action[] = timestamps.map(ts => ({
+              type: 'mouse_click',
+              timestamp: ts,
+              x: 100,
+              y: 100,
+              button: 'left' as const,
+            }));
+
+            const script: ScriptData = {
+              version: '1.0',
+              metadata: {
+                created_at: new Date().toISOString(),
+                duration: actions[actions.length - 1].timestamp,
+                action_count: actions.length,
+                core_type: 'rust',
+                platform: 'macos',
+              },
+              actions,
+            };
+
+            const mockOnPlay = jest.fn();
+            renderScriptPreview(script, validationResult, isSaved, mockOnPlay);
+
+            // Button visibility should be consistent regardless of script size
+            const saveVisible = screen.queryByText(isSaved ? /💾\s*Saved/i : /💾\s*Save Script/i) !== null;
+            const playVisible = isPlayButtonVisible();
+
+            return saveVisible && (isSaved ? playVisible : !playVisible);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('button states are consistent across different action types', () => {
+      fc.assert(
+        fc.property(
+          actionTypeArbitrary,
+          validValidationResultArbitrary,
+          fc.boolean(),
+          (actionType, validationResult, isSaved) => {
+            cleanup();
+
+            // Create a script with a single action of the given type
+            const action: Action = {
+              type: actionType,
+              timestamp: 0,
+              ...(actionType.startsWith('mouse') ? { x: 100, y: 100 } : {}),
+              ...(actionType === 'mouse_click' ? { button: 'left' as const } : {}),
+              ...(actionType === 'key_press' ? { key: 'a' } : {}),
+              ...(actionType === 'key_type' ? { text: 'test' } : {}),
+            };
+
+            const script: ScriptData = {
+              version: '1.0',
+              metadata: {
+                created_at: new Date().toISOString(),
+                duration: 0,
+                action_count: 1,
+                core_type: 'rust',
+                platform: 'macos',
+              },
+              actions: [action],
+            };
+
+            const mockOnPlay = jest.fn();
+            renderScriptPreview(script, validationResult, isSaved, mockOnPlay);
+
+            // Button states should be consistent regardless of action type
+            const saveVisible = screen.queryByText(isSaved ? /💾\s*Saved/i : /💾\s*Save Script/i) !== null;
+            const playVisible = isPlayButtonVisible();
+
+            return saveVisible && (isSaved ? playVisible : !playVisible);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('no buttons are visible when script is null', () => {
+      cleanup();
+      renderScriptPreview(null, { valid: true, errors: [], warnings: [] }, false);
+
+      const saveButton = screen.queryByText(/💾\s*Save Script/i);
+      const playButton = screen.queryByTestId('script-play-button');
+
+      expect(saveButton).not.toBeInTheDocument();
+      expect(playButton).not.toBeInTheDocument();
+    });
+
+    it('button states remain consistent after multiple re-renders', () => {
+      fc.assert(
+        fc.property(
+          validScriptArbitrary,
+          validValidationResultArbitrary,
+          fc.array(fc.boolean(), { minLength: 2, maxLength: 10 }),
+          (script, validationResult, savedStates) => {
+            cleanup();
+            const mockOnPlay = jest.fn();
+            const { rerender } = renderScriptPreview(script, validationResult, savedStates[0], mockOnPlay);
+
+            // Re-render multiple times with different saved states
+            for (let i = 1; i < savedStates.length; i++) {
+              rerender(
+                <ScriptPreview
+                  script={script}
+                  onEdit={jest.fn()}
+                  onSave={jest.fn()}
+                  onDiscard={jest.fn()}
+                  onPlay={mockOnPlay}
+                  validationResult={validationResult}
+                  isSaved={savedStates[i]}
+                  isPlaying={false}
+                />
+              );
+
+              // Check button states match expected state
+              const expectedSaveState = savedStates[i] ? isSaveButtonInSavedState() : isSaveButtonVisibleAndEnabled();
+              const expectedPlayState = savedStates[i] ? isPlayButtonVisible() : !isPlayButtonVisible();
+
+              if (!expectedSaveState || !expectedPlayState) {
+                return false;
+              }
+            }
+
+            return true;
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  /**
+   * Edge cases and boundary conditions
+   */
+  describe('Edge Cases and Boundary Conditions', () => {
+    it('handles script with single action correctly', () => {
+      cleanup();
+      const script: ScriptData = {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration: 0,
+          action_count: 1,
+          core_type: 'rust',
+          platform: 'macos',
+        },
+        actions: [{
+          type: 'mouse_click',
+          timestamp: 0,
+          x: 100,
+          y: 100,
+          button: 'left',
+        }],
+      };
+
+      const mockOnPlay = jest.fn();
+      renderScriptPreview(script, { valid: true, errors: [], warnings: [] }, true, mockOnPlay);
+
+      expect(isSaveButtonInSavedState()).toBe(true);
+      expect(isPlayButtonVisible()).toBe(true);
+    });
+
+    it('handles script with many actions correctly', () => {
+      cleanup();
+      const actions: Action[] = Array.from({ length: 100 }, (_, i) => ({
+        type: 'mouse_click' as const,
+        timestamp: i * 10,
+        x: 100 + i,
+        y: 100 + i,
+        button: 'left' as const,
+      }));
+
+      const script: ScriptData = {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration: 990,
+          action_count: 100,
+          core_type: 'rust',
+          platform: 'macos',
+        },
+        actions,
+      };
+
+      const mockOnPlay = jest.fn();
+      renderScriptPreview(script, { valid: true, errors: [], warnings: [] }, true, mockOnPlay);
+
+      expect(isSaveButtonInSavedState()).toBe(true);
+      expect(isPlayButtonVisible()).toBe(true);
+    });
+
+    it('handles validation result with warnings but no errors', () => {
+      fc.assert(
+        fc.property(
+          validScriptArbitrary,
+          (script) => {
+            cleanup();
+            const validationWithWarnings: ValidationResult = {
+              valid: true,
+              errors: [],
+              warnings: [
+                { field: 'actions[0].timestamp', message: 'Timestamp is very small' },
+              ],
+            };
+
+            const mockOnPlay = jest.fn();
+            renderScriptPreview(script, validationWithWarnings, true, mockOnPlay);
+
+            // Should still allow save and play despite warnings
+            return isSaveButtonInSavedState() && isPlayButtonVisible() && isPlayButtonEnabled();
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+});

--- a/packages/desktop/src/components/__tests__/UnifiedEditorConsistency.property.test.tsx
+++ b/packages/desktop/src/components/__tests__/UnifiedEditorConsistency.property.test.tsx
@@ -1,0 +1,509 @@
+/**
+ * Property-Based Tests for Unified Editor Consistency
+ * 
+ * Tests that the unified editor provides consistent editing capabilities
+ * regardless of script source (recorded or AI-generated).
+ * 
+ * **Feature: ai-script-builder, Property 18: Unified Editor Consistency**
+ * **Validates: Requirements 10.3, 10.6**
+ */
+
+import '@testing-library/jest-dom';
+import { ScriptSource, StoredScriptInfo } from '../../services/scriptStorageService';
+import { ScriptData } from '../../types/aiScriptBuilder.types';
+
+// Mock CSS imports
+jest.mock('../tabs/EditorTabContent.css', () => ({}));
+
+// ============================================================================
+// Test Data Generators
+// ============================================================================
+
+/**
+ * Create a simple recorded script for testing
+ */
+function createRecordedScript(): ScriptData {
+  return {
+    version: '1.0',
+    metadata: {
+      created_at: new Date().toISOString(),
+      duration: 1000,
+      action_count: 2,
+      core_type: 'rust',
+      platform: 'macos',
+    },
+    actions: [
+      { type: 'wait', timestamp: 0 },
+      { type: 'wait', timestamp: 1000 },
+    ],
+  };
+}
+
+/**
+ * Create a simple AI-generated script for testing
+ */
+function createAIScript(): ScriptData {
+  return {
+    version: '1.0',
+    metadata: {
+      created_at: new Date().toISOString(),
+      duration: 1000,
+      action_count: 2,
+      core_type: 'ai_generated',
+      platform: 'macos',
+      additional_data: {
+        source: 'ai_generated',
+        generated_at: new Date().toISOString(),
+        script_name: 'Test AI Script',
+        target_os: 'macos',
+      },
+    },
+    actions: [
+      { type: 'wait', timestamp: 0 },
+      { type: 'wait', timestamp: 1000 },
+    ],
+  };
+}
+
+/**
+ * Create script info for testing
+ */
+function createScriptInfo(source: ScriptSource): StoredScriptInfo {
+  return {
+    filename: source === 'ai_generated' ? 'ai_script_test.json' : 'recording_test.json',
+    path: `/test/${source}_script.json`,
+    createdAt: new Date().toISOString(),
+    duration: 1000,
+    actionCount: 2,
+    source,
+    targetOS: source === 'ai_generated' ? 'macos' : undefined,
+    scriptName: source === 'ai_generated' ? 'Test Script' : undefined,
+  };
+}
+
+// ============================================================================
+// Property Tests
+// ============================================================================
+
+describe('Unified Editor Consistency Property Tests', () => {
+  /**
+   * **Feature: ai-script-builder, Property 18: Unified Editor Consistency**
+   * **Validates: Requirements 10.3, 10.6**
+   * 
+   * For any script (recorded or AI-generated), opening it in the Editor tab
+   * SHALL provide the same editing tools and capabilities.
+   */
+  describe('Property 18: Unified Editor Consistency', () => {
+    it('both script types have view mode toggle (Visual/JSON)', () => {
+      const recordedScript = createRecordedScript();
+      const recordedInfo = createScriptInfo('recorded');
+
+      const { unmount: unmount1 } = render(
+        <EditorTabContent
+          script={recordedScript}
+          selectedScript={recordedInfo}
+          editMode={false}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const recordedHasVisual = !!screen.queryByText('Visual');
+      const recordedHasJson = !!screen.queryByText('JSON');
+      unmount1();
+
+      const aiScript = createAIScript();
+      const aiInfo = createScriptInfo('ai_generated');
+
+      const { unmount: unmount2 } = render(
+        <EditorTabContent
+          script={aiScript}
+          selectedScript={aiInfo}
+          editMode={false}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const aiHasVisual = !!screen.queryByText('Visual');
+      const aiHasJson = !!screen.queryByText('JSON');
+      unmount2();
+
+      expect(recordedHasVisual).toBe(true);
+      expect(recordedHasJson).toBe(true);
+      expect(aiHasVisual).toBe(true);
+      expect(aiHasJson).toBe(true);
+    });
+
+    it('both script types have edit mode toggle', () => {
+      const recordedScript = createRecordedScript();
+      const recordedInfo = createScriptInfo('recorded');
+
+      const { unmount: unmount1 } = render(
+        <EditorTabContent
+          script={recordedScript}
+          selectedScript={recordedInfo}
+          editMode={false}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const recordedHasEdit = !!screen.queryByText(/Edit/);
+      unmount1();
+
+      const aiScript = createAIScript();
+      const aiInfo = createScriptInfo('ai_generated');
+
+      const { unmount: unmount2 } = render(
+        <EditorTabContent
+          script={aiScript}
+          selectedScript={aiInfo}
+          editMode={false}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const aiHasEdit = !!screen.queryByText(/Edit/);
+      unmount2();
+
+      expect(recordedHasEdit).toBe(true);
+      expect(aiHasEdit).toBe(true);
+    });
+
+    it('both script types have save button', () => {
+      const recordedScript = createRecordedScript();
+      const recordedInfo = createScriptInfo('recorded');
+
+      const { unmount: unmount1 } = render(
+        <EditorTabContent
+          script={recordedScript}
+          selectedScript={recordedInfo}
+          editMode={false}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const recordedHasSave = !!screen.queryByText(/Save/);
+      unmount1();
+
+      const aiScript = createAIScript();
+      const aiInfo = createScriptInfo('ai_generated');
+
+      const { unmount: unmount2 } = render(
+        <EditorTabContent
+          script={aiScript}
+          selectedScript={aiInfo}
+          editMode={false}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const aiHasSave = !!screen.queryByText(/Save/);
+      unmount2();
+
+      expect(recordedHasSave).toBe(true);
+      expect(aiHasSave).toBe(true);
+    });
+
+    it('both script types render visual editor by default', () => {
+      const recordedScript = createRecordedScript();
+      const recordedInfo = createScriptInfo('recorded');
+
+      const { unmount: unmount1 } = render(
+        <EditorTabContent
+          script={recordedScript}
+          selectedScript={recordedInfo}
+          editMode={false}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const recordedHasVisual = !!screen.queryByTestId('editor-visual');
+      unmount1();
+
+      const aiScript = createAIScript();
+      const aiInfo = createScriptInfo('ai_generated');
+
+      const { unmount: unmount2 } = render(
+        <EditorTabContent
+          script={aiScript}
+          selectedScript={aiInfo}
+          editMode={false}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const aiHasVisual = !!screen.queryByTestId('editor-visual');
+      unmount2();
+
+      expect(recordedHasVisual).toBe(true);
+      expect(aiHasVisual).toBe(true);
+    });
+
+    it('both script types display action list in visual mode', () => {
+      const recordedScript = createRecordedScript();
+      const recordedInfo = createScriptInfo('recorded');
+
+      const { unmount: unmount1 } = render(
+        <EditorTabContent
+          script={recordedScript}
+          selectedScript={recordedInfo}
+          editMode={false}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const recordedHasAction = !!screen.queryByTestId('editor-action-0');
+      unmount1();
+
+      const aiScript = createAIScript();
+      const aiInfo = createScriptInfo('ai_generated');
+
+      const { unmount: unmount2 } = render(
+        <EditorTabContent
+          script={aiScript}
+          selectedScript={aiInfo}
+          editMode={false}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const aiHasAction = !!screen.queryByTestId('editor-action-0');
+      unmount2();
+
+      expect(recordedHasAction).toBe(true);
+      expect(aiHasAction).toBe(true);
+    });
+
+    it('edit mode enables action editing for both script types', () => {
+      const recordedScript = createRecordedScript();
+      const recordedInfo = createScriptInfo('recorded');
+
+      const { unmount: unmount1 } = render(
+        <EditorTabContent
+          script={recordedScript}
+          selectedScript={recordedInfo}
+          editMode={true}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const recordedHasDelete = !!screen.queryByLabelText(/Delete action/);
+      unmount1();
+
+      const aiScript = createAIScript();
+      const aiInfo = createScriptInfo('ai_generated');
+
+      const { unmount: unmount2 } = render(
+        <EditorTabContent
+          script={aiScript}
+          selectedScript={aiInfo}
+          editMode={true}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const aiHasDelete = !!screen.queryByLabelText(/Delete action/);
+      unmount2();
+
+      expect(recordedHasDelete).toBe(true);
+      expect(aiHasDelete).toBe(true);
+    });
+
+    it('save button is disabled when not in edit mode for both script types', () => {
+      const recordedScript = createRecordedScript();
+      const recordedInfo = createScriptInfo('recorded');
+
+      const { unmount: unmount1 } = render(
+        <EditorTabContent
+          script={recordedScript}
+          selectedScript={recordedInfo}
+          editMode={false}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const recordedSaveButton = screen.queryByText(/Save/);
+      const recordedIsDisabled = recordedSaveButton?.closest('button')?.disabled;
+      unmount1();
+
+      const aiScript = createAIScript();
+      const aiInfo = createScriptInfo('ai_generated');
+
+      const { unmount: unmount2 } = render(
+        <EditorTabContent
+          script={aiScript}
+          selectedScript={aiInfo}
+          editMode={false}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const aiSaveButton = screen.queryByText(/Save/);
+      const aiIsDisabled = aiSaveButton?.closest('button')?.disabled;
+      unmount2();
+
+      expect(recordedIsDisabled).toBe(true);
+      expect(aiIsDisabled).toBe(true);
+    });
+  });
+
+
+  /**
+   * Edge cases and boundary conditions
+   */
+  describe('Edge Cases and Boundary Conditions', () => {
+    it('handles scripts with no actions', () => {
+      const emptyScript: ScriptData = {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration: 0,
+          action_count: 0,
+          core_type: 'rust',
+          platform: 'macos',
+        },
+        actions: [],
+      };
+
+      const scriptInfo: StoredScriptInfo = {
+        filename: 'empty_script.json',
+        path: '/test/empty_script.json',
+        createdAt: new Date().toISOString(),
+        duration: 0,
+        actionCount: 0,
+        source: 'recorded',
+      };
+
+      const { unmount } = render(
+        <EditorTabContent
+          script={emptyScript}
+          selectedScript={scriptInfo}
+          editMode={false}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const hasEditingTools = !!(
+        screen.queryByText('Visual') &&
+        screen.queryByText('JSON') &&
+        screen.queryByText(/Edit/) &&
+        screen.queryByText(/Save/)
+      );
+      unmount();
+
+      expect(hasEditingTools).toBe(true);
+    });
+
+    it('handles null script by showing placeholder', () => {
+      const { unmount } = render(
+        <EditorTabContent
+          script={null}
+          selectedScript={null}
+          editMode={false}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const placeholder = screen.queryByTestId('editor-placeholder');
+      unmount();
+
+      expect(placeholder).not.toBeNull();
+    });
+
+    it('handles AI script without target OS metadata', () => {
+      const script: ScriptData = {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration: 100,
+          action_count: 1,
+          core_type: 'ai_generated',
+          platform: 'macos',
+          additional_data: {
+            source: 'ai_generated',
+            script_name: 'Test Script',
+          },
+        },
+        actions: [{ type: 'wait', timestamp: 100 }],
+      };
+
+      const scriptInfo: StoredScriptInfo = {
+        filename: 'ai_script_test.json',
+        path: '/test/ai_script_test.json',
+        createdAt: new Date().toISOString(),
+        duration: 100,
+        actionCount: 1,
+        source: 'ai_generated',
+      };
+
+      const { unmount } = render(
+        <EditorTabContent
+          script={script}
+          selectedScript={scriptInfo}
+          editMode={false}
+          onEditModeChange={() => { }}
+          onScriptSave={() => { }}
+          onActionUpdate={() => { }}
+          onActionDelete={() => { }}
+        />
+      );
+
+      const hasEditingTools = !!(
+        screen.queryByText('Visual') &&
+        screen.queryByText('JSON') &&
+        screen.queryByText(/Edit/) &&
+        screen.queryByText(/Save/)
+      );
+      unmount();
+
+      expect(hasEditingTools).toBe(true);
+    });
+  });
+});

--- a/packages/desktop/src/screens/UnifiedScriptManager.tsx
+++ b/packages/desktop/src/screens/UnifiedScriptManager.tsx
@@ -9,31 +9,31 @@
  * Requirements: 10.1, 10.2, 10.3, 10.4, 10.5, 10.6
  */
 
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 
 // Components
+import { AIChatInterface } from '../components/AIChatInterface';
+import { OSSelector } from '../components/OSSelector';
+import { ProviderSettings } from '../components/ProviderSettings';
 import { ScriptFilter } from '../components/ScriptFilter';
 import { ScriptListItem } from '../components/ScriptListItem';
-import { AIChatInterface } from '../components/AIChatInterface';
-import { ScriptPreview } from '../components/ScriptPreview';
 import { ScriptNameDialog } from '../components/ScriptNameDialog';
-import { ProviderSettings } from '../components/ProviderSettings';
+import { ScriptPreview } from '../components/ScriptPreview';
 import { UsageStatistics } from '../components/UsageStatistics';
-import { OSSelector } from '../components/OSSelector';
 
 // Services
-import { scriptStorageService, StoredScriptInfo, ScriptFilter as ScriptFilterType, TargetOS } from '../services/scriptStorageService';
-import { unifiedAIService } from '../services/unifiedAIService';
-import { providerManager } from '../services/providerManager';
-import { validateScript } from '../services/scriptValidationService';
 import { getIPCBridge } from '../services/ipcBridgeService';
+import { providerManager } from '../services/providerManager';
+import { ScriptFilter as ScriptFilterType, scriptStorageService, StoredScriptInfo, TargetOS } from '../services/scriptStorageService';
+import { validateScript } from '../services/scriptValidationService';
+import { unifiedAIService } from '../services/unifiedAIService';
 
 // Types
-import { ScriptData, ValidationResult, Action } from '../types/aiScriptBuilder.types';
+import { open, save } from '@tauri-apps/api/dialog';
+import { Action, ScriptData, ValidationResult } from '../types/aiScriptBuilder.types';
 import { AIProvider, ProviderInfo, ProviderModel, SessionStatistics } from '../types/providerAdapter.types';
-import { save, open } from '@tauri-apps/api/dialog';
 
 import './UnifiedScriptManager.css';
 
@@ -349,7 +349,7 @@ const UnifiedScriptManager: React.FC<UnifiedScriptManagerProps> = ({
 
   /**
    * Handle actual script save with name
-   * Requirements: 10.5
+   * Requirements: 10.5, 7.3, 8.6
    */
   const handleSaveWithName = useCallback(async (scriptName: string) => {
     if (!generatedScript) {
@@ -361,7 +361,7 @@ const UnifiedScriptManager: React.FC<UnifiedScriptManagerProps> = ({
     setSaveError(null);
 
     try {
-      const result = await scriptStorageService.saveScript(generatedScript, scriptName);
+      const result = await scriptStorageService.saveScript(generatedScript, scriptName, targetOS);
 
       if (result.success) {
         console.log('[UnifiedScriptManager] Script saved successfully:', result.scriptPath);

--- a/packages/desktop/src/services/__tests__/aiScriptMetadata.property.test.ts
+++ b/packages/desktop/src/services/__tests__/aiScriptMetadata.property.test.ts
@@ -1,0 +1,790 @@
+/**
+ * Property-Based Tests for AI Script Metadata Consistency
+ * 
+ * Tests that AI-generated scripts are saved with the correct metadata fields.
+ * For any saved AI-generated script, the metadata should contain:
+ * - source='ai_generated'
+ * - generated_at timestamp
+ * - script_name
+ * - target_os
+ * 
+ * **Feature: ai-script-builder, Property 12: AI Script Metadata Consistency**
+ * **Validates: Requirements 7.3, 8.6**
+ */
+
+import * as fc from 'fast-check';
+import {
+    Action,
+    ActionType,
+    ScriptData,
+    ScriptMetadata,
+} from '../../types/aiScriptBuilder.types';
+import { prepareScriptForSave, TargetOS } from '../scriptStorageService';
+
+// ============================================================================
+// Arbitraries (Generators)
+// ============================================================================
+
+/**
+ * Generate a valid target OS
+ */
+const targetOSArbitrary: fc.Arbitrary<TargetOS> = fc.constantFrom(
+  'macos',
+  'windows',
+  'universal'
+);
+
+/**
+ * Generate a valid action type
+ */
+const actionTypeArbitrary: fc.Arbitrary<ActionType> = fc.constantFrom(
+  'mouse_move',
+  'mouse_click',
+  'mouse_double_click',
+  'mouse_drag',
+  'mouse_scroll',
+  'key_press',
+  'key_release',
+  'key_type',
+  'screenshot',
+  'wait',
+  'custom'
+);
+
+/**
+ * Generate a valid action
+ */
+const actionArbitrary = (timestamp: number): fc.Arbitrary<Action> => {
+  return fc.oneof(
+    // Mouse actions
+    fc.record({
+      type: fc.constantFrom('mouse_move' as const, 'mouse_click' as const),
+      timestamp: fc.constant(timestamp),
+      x: fc.integer({ min: 0, max: 1920 }),
+      y: fc.integer({ min: 0, max: 1080 }),
+      button: fc.option(fc.constantFrom('left' as const, 'right' as const, 'middle' as const), { nil: undefined }),
+    }),
+    // Keyboard actions
+    fc.record({
+      type: fc.constantFrom('key_press' as const, 'key_release' as const),
+      timestamp: fc.constant(timestamp),
+      key: fc.constantFrom('a', 'b', 'c', 'enter', 'escape', 'tab'),
+      modifiers: fc.option(fc.array(fc.constantFrom('ctrl', 'shift', 'alt', 'meta'), { maxLength: 2 }), { nil: undefined }),
+    }),
+    // Key type action
+    fc.record({
+      type: fc.constant('key_type' as const),
+      timestamp: fc.constant(timestamp),
+      text: fc.string({ minLength: 1, maxLength: 50 }),
+    }),
+    // Wait action
+    fc.record({
+      type: fc.constant('wait' as const),
+      timestamp: fc.constant(timestamp),
+    })
+  );
+};
+
+/**
+ * Generate basic script metadata (without AI-specific fields)
+ */
+const basicScriptMetadataArbitrary = (actionCount: number, duration: number): fc.Arbitrary<ScriptMetadata> => {
+  return fc.record({
+    created_at: fc.date({ min: new Date('2020-01-01'), max: new Date('2030-12-31') })
+      .map(d => d.toISOString()),
+    duration: fc.constant(duration),
+    action_count: fc.constant(actionCount),
+    core_type: fc.constantFrom('rust', 'ai_generated', 'recorded'),
+    platform: fc.constantFrom('macos', 'windows', 'linux', 'universal'),
+    screen_resolution: fc.option(
+      fc.tuple(
+        fc.integer({ min: 800, max: 3840 }),
+        fc.integer({ min: 600, max: 2160 })
+      ) as fc.Arbitrary<[number, number]>,
+      { nil: undefined }
+    ),
+    additional_data: fc.option(
+      fc.dictionary(fc.string(), fc.anything()),
+      { nil: undefined }
+    ),
+  });
+};
+
+/**
+ * Generate a valid script with basic metadata (before AI processing)
+ */
+const basicScriptArbitrary: fc.Arbitrary<ScriptData> = fc
+  .integer({ min: 1, max: 20 })
+  .chain(actionCount => {
+    // Generate timestamps in ascending order
+    const timestamps = Array.from({ length: actionCount }, (_, i) => i * 500);
+
+    // Generate actions with those timestamps
+    const actionsArb = fc.array(
+      fc.integer({ min: 0, max: actionCount - 1 }).chain(idx =>
+        actionArbitrary(timestamps[idx])
+      ),
+      { minLength: actionCount, maxLength: actionCount }
+    );
+
+    return actionsArb.map(actions => {
+      // Sort by timestamp to ensure order
+      actions.sort((a, b) => a.timestamp - b.timestamp);
+      const duration = actions.length > 0 ? actions[actions.length - 1].timestamp : 0;
+
+      return {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration,
+          action_count: actions.length,
+          core_type: 'rust',
+          platform: 'macos',
+        },
+        actions,
+      };
+    });
+  });
+
+/**
+ * Generate a valid script name
+ */
+const scriptNameArbitrary: fc.Arbitrary<string> = fc.oneof(
+  fc.string({ minLength: 5, maxLength: 50 })
+    .filter(s => s.trim().length >= 5)
+    .map(s => s.replace(/[^a-zA-Z0-9_\-\s]/g, '')),
+  fc.constantFrom(
+    'Login Test',
+    'Navigation Flow',
+    'Form Submission',
+    'Data Entry Script',
+    'UI Automation Test'
+  )
+);
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Check if metadata contains all required AI-generated script fields
+ */
+function hasRequiredAIMetadata(
+  metadata: ScriptMetadata,
+  expectedScriptName: string,
+  expectedTargetOS?: TargetOS
+): boolean {
+  const additionalData = metadata.additional_data;
+  
+  if (!additionalData) {
+    return false;
+  }
+
+  // Check for source='ai_generated'
+  if (additionalData.source !== 'ai_generated') {
+    return false;
+  }
+
+  // Check for generated_at timestamp
+  if (!additionalData.generated_at || typeof additionalData.generated_at !== 'string') {
+    return false;
+  }
+
+  // Validate generated_at is a valid ISO 8601 timestamp
+  const generatedAt = new Date(additionalData.generated_at as string);
+  if (isNaN(generatedAt.getTime())) {
+    return false;
+  }
+
+  // Check for script_name
+  if (!additionalData.script_name || additionalData.script_name !== expectedScriptName) {
+    return false;
+  }
+
+  // Check for target_os if provided
+  if (expectedTargetOS !== undefined) {
+    if (!additionalData.target_os || additionalData.target_os !== expectedTargetOS) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Extract AI metadata fields from script metadata
+ */
+function extractAIMetadata(metadata: ScriptMetadata): {
+  source?: string;
+  generated_at?: string;
+  script_name?: string;
+  target_os?: string;
+} {
+  const additionalData = metadata.additional_data || {};
+  
+  return {
+    source: additionalData.source as string | undefined,
+    generated_at: additionalData.generated_at as string | undefined,
+    script_name: additionalData.script_name as string | undefined,
+    target_os: additionalData.target_os as string | undefined,
+  };
+}
+
+/**
+ * Check if a timestamp is recent (within last 5 seconds)
+ */
+function isRecentTimestamp(timestamp: string): boolean {
+  const now = new Date();
+  const ts = new Date(timestamp);
+  const diffMs = now.getTime() - ts.getTime();
+  return diffMs >= 0 && diffMs <= 5000; // Within 5 seconds
+}
+
+// ============================================================================
+// Property Tests
+// ============================================================================
+
+describe('AI Script Metadata Consistency Property Tests', () => {
+  /**
+   * **Feature: ai-script-builder, Property 12: AI Script Metadata Consistency**
+   * **Validates: Requirements 7.3, 8.6**
+   * 
+   * For any saved AI-generated script, the metadata SHALL contain:
+   * - source='ai_generated'
+   * - generated_at timestamp
+   * - script_name
+   * - target_os (when specified)
+   */
+  describe('Property 12: AI Script Metadata Consistency', () => {
+    it('prepareScriptForSave adds all required AI metadata fields', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          targetOSArbitrary,
+          (script, scriptName, targetOS) => {
+            const preparedScript = prepareScriptForSave(script, scriptName, targetOS);
+            
+            return hasRequiredAIMetadata(preparedScript.metadata, scriptName, targetOS);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('prepareScriptForSave sets source to ai_generated', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          (script, scriptName) => {
+            const preparedScript = prepareScriptForSave(script, scriptName);
+            const aiMetadata = extractAIMetadata(preparedScript.metadata);
+            
+            return aiMetadata.source === 'ai_generated';
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('prepareScriptForSave adds generated_at timestamp', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          (script, scriptName) => {
+            const preparedScript = prepareScriptForSave(script, scriptName);
+            const aiMetadata = extractAIMetadata(preparedScript.metadata);
+            
+            // Should have generated_at field
+            if (!aiMetadata.generated_at) {
+              return false;
+            }
+
+            // Should be a valid ISO 8601 timestamp
+            const timestamp = new Date(aiMetadata.generated_at);
+            if (isNaN(timestamp.getTime())) {
+              return false;
+            }
+
+            // Should be a recent timestamp (within last 5 seconds)
+            return isRecentTimestamp(aiMetadata.generated_at);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('prepareScriptForSave preserves script_name', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          (script, scriptName) => {
+            const preparedScript = prepareScriptForSave(script, scriptName);
+            const aiMetadata = extractAIMetadata(preparedScript.metadata);
+            
+            return aiMetadata.script_name === scriptName;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('prepareScriptForSave includes target_os when provided', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          targetOSArbitrary,
+          (script, scriptName, targetOS) => {
+            const preparedScript = prepareScriptForSave(script, scriptName, targetOS);
+            const aiMetadata = extractAIMetadata(preparedScript.metadata);
+            
+            return aiMetadata.target_os === targetOS;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('prepareScriptForSave does not include target_os when not provided', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          (script, scriptName) => {
+            const preparedScript = prepareScriptForSave(script, scriptName, undefined);
+            const aiMetadata = extractAIMetadata(preparedScript.metadata);
+            
+            // target_os should not be present when not provided
+            return aiMetadata.target_os === undefined;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('prepareScriptForSave preserves existing metadata fields', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          (script, scriptName) => {
+            const originalCreatedAt = script.metadata.created_at;
+            const originalPlatform = script.metadata.platform;
+            
+            const preparedScript = prepareScriptForSave(script, scriptName);
+            
+            // Original fields should be preserved
+            return preparedScript.metadata.created_at === originalCreatedAt &&
+                   preparedScript.metadata.platform === originalPlatform;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('prepareScriptForSave updates action_count to match actual actions', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          (script, scriptName) => {
+            const preparedScript = prepareScriptForSave(script, scriptName);
+            
+            return preparedScript.metadata.action_count === preparedScript.actions.length;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('prepareScriptForSave sets version to 1.0 if not present', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          (script, scriptName) => {
+            // Remove version
+            const scriptWithoutVersion = { ...script, version: undefined as any };
+            
+            const preparedScript = prepareScriptForSave(scriptWithoutVersion, scriptName);
+            
+            return preparedScript.version === '1.0';
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('prepareScriptForSave preserves existing version', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          fc.constantFrom('1.0', '1.1', '2.0'),
+          (script, scriptName, version) => {
+            const scriptWithVersion = { ...script, version };
+            
+            const preparedScript = prepareScriptForSave(scriptWithVersion, scriptName);
+            
+            return preparedScript.version === version;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('prepareScriptForSave adds generated_by field', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          (script, scriptName) => {
+            const preparedScript = prepareScriptForSave(script, scriptName);
+            const additionalData = preparedScript.metadata.additional_data;
+            
+            return additionalData?.generated_by === 'ai_script_builder';
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('prepareScriptForSave preserves existing additional_data fields', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          fc.string({ minLength: 5, maxLength: 20 }),
+          fc.string({ minLength: 5, maxLength: 20 }),
+          (script, scriptName, customKey, customValue) => {
+            // Add custom field to additional_data
+            const scriptWithCustomData = {
+              ...script,
+              metadata: {
+                ...script.metadata,
+                additional_data: {
+                  [customKey]: customValue,
+                },
+              },
+            };
+            
+            const preparedScript = prepareScriptForSave(scriptWithCustomData, scriptName);
+            const additionalData = preparedScript.metadata.additional_data;
+            
+            // Custom field should be preserved
+            return additionalData?.[customKey] === customValue;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('metadata is consistent across multiple preparations of same script', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          targetOSArbitrary,
+          (script, scriptName, targetOS) => {
+            const prepared1 = prepareScriptForSave(script, scriptName, targetOS);
+            const prepared2 = prepareScriptForSave(script, scriptName, targetOS);
+            
+            const meta1 = extractAIMetadata(prepared1.metadata);
+            const meta2 = extractAIMetadata(prepared2.metadata);
+            
+            // Core fields should be consistent
+            return meta1.source === meta2.source &&
+                   meta1.script_name === meta2.script_name &&
+                   meta1.target_os === meta2.target_os;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('different script names produce different metadata', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          scriptNameArbitrary,
+          (script, scriptName1, scriptName2) => {
+            // Ensure names are different
+            if (scriptName1 === scriptName2) {
+              return true; // Skip this case
+            }
+            
+            const prepared1 = prepareScriptForSave(script, scriptName1);
+            const prepared2 = prepareScriptForSave(script, scriptName2);
+            
+            const meta1 = extractAIMetadata(prepared1.metadata);
+            const meta2 = extractAIMetadata(prepared2.metadata);
+            
+            return meta1.script_name !== meta2.script_name;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('different target OS values produce different metadata', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          (script, scriptName) => {
+            const preparedMacOS = prepareScriptForSave(script, scriptName, 'macos');
+            const preparedWindows = prepareScriptForSave(script, scriptName, 'windows');
+            const preparedUniversal = prepareScriptForSave(script, scriptName, 'universal');
+            
+            const metaMacOS = extractAIMetadata(preparedMacOS.metadata);
+            const metaWindows = extractAIMetadata(preparedWindows.metadata);
+            const metaUniversal = extractAIMetadata(preparedUniversal.metadata);
+            
+            return metaMacOS.target_os === 'macos' &&
+                   metaWindows.target_os === 'windows' &&
+                   metaUniversal.target_os === 'universal' &&
+                   metaMacOS.target_os !== metaWindows.target_os &&
+                   metaWindows.target_os !== metaUniversal.target_os;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('prepareScriptForSave handles scripts with no actions', () => {
+      fc.assert(
+        fc.property(
+          scriptNameArbitrary,
+          targetOSArbitrary,
+          (scriptName, targetOS) => {
+            const emptyScript: ScriptData = {
+              version: '1.0',
+              metadata: {
+                created_at: new Date().toISOString(),
+                duration: 0,
+                action_count: 0,
+                core_type: 'rust',
+                platform: 'macos',
+              },
+              actions: [],
+            };
+            
+            const preparedScript = prepareScriptForSave(emptyScript, scriptName, targetOS);
+            
+            return hasRequiredAIMetadata(preparedScript.metadata, scriptName, targetOS) &&
+                   preparedScript.metadata.action_count === 0;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('prepareScriptForSave handles scripts with many actions', () => {
+      fc.assert(
+        fc.property(
+          scriptNameArbitrary,
+          targetOSArbitrary,
+          fc.integer({ min: 50, max: 100 }),
+          (scriptName, targetOS, actionCount) => {
+            const actions: Action[] = Array.from({ length: actionCount }, (_, i) => ({
+              type: 'mouse_click' as const,
+              timestamp: i * 100,
+              x: 100 + i,
+              y: 100 + i,
+              button: 'left' as const,
+            }));
+
+            const largeScript: ScriptData = {
+              version: '1.0',
+              metadata: {
+                created_at: new Date().toISOString(),
+                duration: actions[actions.length - 1].timestamp,
+                action_count: actions.length,
+                core_type: 'rust',
+                platform: 'macos',
+              },
+              actions,
+            };
+            
+            const preparedScript = prepareScriptForSave(largeScript, scriptName, targetOS);
+            
+            return hasRequiredAIMetadata(preparedScript.metadata, scriptName, targetOS) &&
+                   preparedScript.metadata.action_count === actionCount;
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('prepareScriptForSave handles special characters in script names', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          fc.constantFrom(
+            'Test-Script_123',
+            'My Script (v2)',
+            'Script #1',
+            'Test & Verify',
+            'Script [Final]'
+          ),
+          (script, scriptName) => {
+            const preparedScript = prepareScriptForSave(script, scriptName);
+            const aiMetadata = extractAIMetadata(preparedScript.metadata);
+            
+            return aiMetadata.script_name === scriptName;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('generated_at timestamp is always in ISO 8601 format', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          (script, scriptName) => {
+            const preparedScript = prepareScriptForSave(script, scriptName);
+            const aiMetadata = extractAIMetadata(preparedScript.metadata);
+            
+            if (!aiMetadata.generated_at) {
+              return false;
+            }
+
+            // Check ISO 8601 format (basic validation)
+            const iso8601Regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+            return iso8601Regex.test(aiMetadata.generated_at);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('prepareScriptForSave is idempotent for AI metadata', () => {
+      fc.assert(
+        fc.property(
+          basicScriptArbitrary,
+          scriptNameArbitrary,
+          targetOSArbitrary,
+          (script, scriptName, targetOS) => {
+            const prepared1 = prepareScriptForSave(script, scriptName, targetOS);
+            const prepared2 = prepareScriptForSave(prepared1, scriptName, targetOS);
+            
+            const meta1 = extractAIMetadata(prepared1.metadata);
+            const meta2 = extractAIMetadata(prepared2.metadata);
+            
+            // Core fields should remain the same (except generated_at which updates)
+            return meta1.source === meta2.source &&
+                   meta1.script_name === meta2.script_name &&
+                   meta1.target_os === meta2.target_os;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Edge cases and boundary conditions
+   */
+  describe('Edge Cases and Boundary Conditions', () => {
+    it('handles empty script name', () => {
+      const script: ScriptData = {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration: 0,
+          action_count: 1,
+          core_type: 'rust',
+          platform: 'macos',
+        },
+        actions: [{
+          type: 'wait',
+          timestamp: 0,
+        }],
+      };
+
+      const preparedScript = prepareScriptForSave(script, '');
+      const aiMetadata = extractAIMetadata(preparedScript.metadata);
+      
+      expect(aiMetadata.script_name).toBe('');
+      expect(aiMetadata.source).toBe('ai_generated');
+    });
+
+    it('handles very long script names', () => {
+      const longName = 'A'.repeat(500);
+      const script: ScriptData = {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration: 0,
+          action_count: 1,
+          core_type: 'rust',
+          platform: 'macos',
+        },
+        actions: [{
+          type: 'wait',
+          timestamp: 0,
+        }],
+      };
+
+      const preparedScript = prepareScriptForSave(script, longName);
+      const aiMetadata = extractAIMetadata(preparedScript.metadata);
+      
+      expect(aiMetadata.script_name).toBe(longName);
+    });
+
+    it('handles script with undefined metadata fields', () => {
+      const script: ScriptData = {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration: 0,
+          action_count: 1,
+          core_type: 'rust',
+          platform: 'macos',
+          additional_data: undefined,
+        },
+        actions: [{
+          type: 'wait',
+          timestamp: 0,
+        }],
+      };
+
+      const preparedScript = prepareScriptForSave(script, 'Test Script', 'macos');
+      
+      expect(hasRequiredAIMetadata(preparedScript.metadata, 'Test Script', 'macos')).toBe(true);
+    });
+
+    it('handles all valid target OS values', () => {
+      const script: ScriptData = {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration: 0,
+          action_count: 1,
+          core_type: 'rust',
+          platform: 'macos',
+        },
+        actions: [{
+          type: 'wait',
+          timestamp: 0,
+        }],
+      };
+
+      const targetOSValues: TargetOS[] = ['macos', 'windows', 'universal'];
+      
+      for (const targetOS of targetOSValues) {
+        const preparedScript = prepareScriptForSave(script, 'Test', targetOS);
+        const aiMetadata = extractAIMetadata(preparedScript.metadata);
+        
+        expect(aiMetadata.target_os).toBe(targetOS);
+      }
+    });
+  });
+});

--- a/packages/desktop/src/services/__tests__/aiScriptPlaybackCompatibility.property.test.ts
+++ b/packages/desktop/src/services/__tests__/aiScriptPlaybackCompatibility.property.test.ts
@@ -1,0 +1,989 @@
+/**
+ * Property-Based Tests for AI Script Playback Compatibility
+ * 
+ * Tests that AI-generated scripts can be loaded and played in the Desktop Recorder
+ * with the same playback controls as recorded scripts.
+ * 
+ * For any AI-generated script, selecting it in the Recorder should load it with
+ * the same playback controls as recorded scripts.
+ * 
+ * **Feature: ai-script-builder, Property 17: AI Script Playback Compatibility**
+ * **Validates: Requirements 9.3**
+ */
+
+import * as fc from 'fast-check';
+import {
+    Action,
+    ActionType,
+    ScriptData
+} from '../../types/aiScriptBuilder.types';
+import { IPCEvent } from '../../types/recorder.types';
+import { getIPCBridge, resetIPCBridge } from '../ipcBridgeService';
+import { getPlaybackService, PlaybackService, resetPlaybackService } from '../playbackService';
+import { prepareScriptForSave, TargetOS } from '../scriptStorageService';
+
+// Mock the IPC bridge
+jest.mock('../ipcBridgeService');
+
+// Suppress PlaybackService console output for the whole module. fast-check runs
+// each property many times and the service logs on every start; restoring the
+// spy per-test would let late async logs trip jest's "log after teardown" guard.
+beforeAll(() => {
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterAll(() => {
+  (console.log as jest.Mock).mockRestore?.();
+  (console.error as jest.Mock).mockRestore?.();
+});
+
+// ============================================================================
+// Arbitraries (Generators)
+// ============================================================================
+
+/**
+ * Generate a valid target OS
+ */
+const targetOSArbitrary: fc.Arbitrary<TargetOS> = fc.constantFrom(
+  'macos',
+  'windows',
+  'universal'
+);
+
+/**
+ * Generate a valid action type
+ */
+const actionTypeArbitrary: fc.Arbitrary<ActionType> = fc.constantFrom(
+  'mouse_move',
+  'mouse_click',
+  'mouse_double_click',
+  'mouse_drag',
+  'mouse_scroll',
+  'key_press',
+  'key_release',
+  'key_type',
+  'screenshot',
+  'wait',
+  'custom'
+);
+
+/**
+ * Generate a valid action
+ */
+const actionArbitrary = (timestamp: number): fc.Arbitrary<Action> => {
+  return fc.oneof(
+    // Mouse actions
+    fc.record({
+      type: fc.constantFrom('mouse_move' as const, 'mouse_click' as const),
+      timestamp: fc.constant(timestamp),
+      x: fc.integer({ min: 0, max: 1920 }),
+      y: fc.integer({ min: 0, max: 1080 }),
+      button: fc.option(fc.constantFrom('left' as const, 'right' as const, 'middle' as const), { nil: undefined }),
+    }),
+    // Keyboard actions
+    fc.record({
+      type: fc.constantFrom('key_press' as const, 'key_release' as const),
+      timestamp: fc.constant(timestamp),
+      key: fc.constantFrom('a', 'b', 'c', 'enter', 'escape', 'tab'),
+      modifiers: fc.option(fc.array(fc.constantFrom('ctrl', 'shift', 'alt', 'meta'), { maxLength: 2 }), { nil: undefined }),
+    }),
+    // Key type action
+    fc.record({
+      type: fc.constant('key_type' as const),
+      timestamp: fc.constant(timestamp),
+      text: fc.string({ minLength: 1, maxLength: 50 }),
+    }),
+    // Wait action
+    fc.record({
+      type: fc.constant('wait' as const),
+      timestamp: fc.constant(timestamp),
+    })
+  );
+};
+
+/**
+ * Generate a valid AI-generated script
+ */
+const aiGeneratedScriptArbitrary: fc.Arbitrary<ScriptData> = fc
+  .integer({ min: 1, max: 20 })
+  .chain(actionCount => {
+    // Generate timestamps in ascending order
+    const timestamps = Array.from({ length: actionCount }, (_, i) => i * 500);
+
+    // Generate actions with those timestamps
+    const actionsArb = fc.array(
+      fc.integer({ min: 0, max: actionCount - 1 }).chain(idx =>
+        actionArbitrary(timestamps[idx])
+      ),
+      { minLength: actionCount, maxLength: actionCount }
+    );
+
+    return actionsArb.map(actions => {
+      // Sort by timestamp to ensure order
+      actions.sort((a, b) => a.timestamp - b.timestamp);
+      const duration = actions.length > 0 ? actions[actions.length - 1].timestamp : 0;
+
+      return {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration,
+          action_count: actions.length,
+          core_type: 'rust',
+          platform: 'macos',
+          additional_data: {
+            source: 'ai_generated',
+            generated_at: new Date().toISOString(),
+            generated_by: 'ai_script_builder',
+            script_name: 'Test AI Script',
+            target_os: 'macos',
+          },
+        },
+        actions,
+      };
+    });
+  });
+
+/**
+ * Generate a valid recorded script (for comparison)
+ */
+const recordedScriptArbitrary: fc.Arbitrary<ScriptData> = fc
+  .integer({ min: 1, max: 20 })
+  .chain(actionCount => {
+    // Generate timestamps in ascending order
+    const timestamps = Array.from({ length: actionCount }, (_, i) => i * 500);
+
+    // Generate actions with those timestamps
+    const actionsArb = fc.array(
+      fc.integer({ min: 0, max: actionCount - 1 }).chain(idx =>
+        actionArbitrary(timestamps[idx])
+      ),
+      { minLength: actionCount, maxLength: actionCount }
+    );
+
+    return actionsArb.map(actions => {
+      // Sort by timestamp to ensure order
+      actions.sort((a, b) => a.timestamp - b.timestamp);
+      const duration = actions.length > 0 ? actions[actions.length - 1].timestamp : 0;
+
+      return {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration,
+          action_count: actions.length,
+          core_type: 'rust',
+          platform: 'macos',
+          additional_data: {
+            source: 'recorded',
+          },
+        },
+        actions,
+      };
+    });
+  });
+
+/**
+ * Generate a valid script name
+ */
+const scriptNameArbitrary: fc.Arbitrary<string> = fc.oneof(
+  fc.string({ minLength: 5, maxLength: 50 })
+    .filter(s => s.trim().length >= 5)
+    .map(s => s.replace(/[^a-zA-Z0-9_\-\s]/g, '')),
+  fc.constantFrom(
+    'Login Test',
+    'Navigation Flow',
+    'Form Submission',
+    'Data Entry Script',
+    'UI Automation Test'
+  )
+);
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Check if a script has AI-generated metadata
+ */
+function isAIGeneratedScript(script: ScriptData): boolean {
+  return script.metadata.additional_data?.source === 'ai_generated';
+}
+
+/**
+ * Check if a script has recorded metadata
+ */
+function isRecordedScript(script: ScriptData): boolean {
+  return script.metadata.additional_data?.source === 'recorded';
+}
+
+/**
+ * Extract playback capabilities from a script
+ * These are the controls that should be available for any script
+ */
+interface PlaybackCapabilities {
+  canStart: boolean;
+  canStop: boolean;
+  canPause: boolean;
+  canResume: boolean;
+  hasProgressTracking: boolean;
+  hasErrorHandling: boolean;
+}
+
+/**
+ * Get playback capabilities for a script
+ * All scripts (AI-generated or recorded) should have the same capabilities
+ */
+function getPlaybackCapabilities(script: ScriptData): PlaybackCapabilities {
+  // All valid scripts should have the same playback capabilities
+  const hasValidActions = script.actions && script.actions.length > 0;
+  const hasValidMetadata = script.metadata && !!script.version;
+
+  const canPlayback = hasValidActions && hasValidMetadata;
+
+  return {
+    canStart: canPlayback,
+    canStop: canPlayback,
+    canPause: canPlayback,
+    canResume: canPlayback,
+    hasProgressTracking: canPlayback,
+    hasErrorHandling: canPlayback,
+  };
+}
+
+/**
+ * Compare playback capabilities between two scripts
+ */
+function haveSamePlaybackCapabilities(
+  capabilities1: PlaybackCapabilities,
+  capabilities2: PlaybackCapabilities
+): boolean {
+  return (
+    capabilities1.canStart === capabilities2.canStart &&
+    capabilities1.canStop === capabilities2.canStop &&
+    capabilities1.canPause === capabilities2.canPause &&
+    capabilities1.canResume === capabilities2.canResume &&
+    capabilities1.hasProgressTracking === capabilities2.hasProgressTracking &&
+    capabilities1.hasErrorHandling === capabilities2.hasErrorHandling
+  );
+}
+
+/**
+ * Setup mock IPC bridge for testing
+ */
+function setupMockIPCBridge() {
+  const eventListeners = new Map<string, ((event: IPCEvent) => void)[]>();
+
+  const mockIPCBridge = {
+    startPlayback: jest.fn().mockResolvedValue(undefined),
+    stopPlayback: jest.fn().mockResolvedValue(undefined),
+    pausePlayback: jest.fn().mockResolvedValue(false),
+    loadScript: jest.fn().mockImplementation(async (scriptPath: string) => {
+      // Return a mock script based on the path
+      return {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration: 1000,
+          action_count: 2,
+          core_type: 'rust',
+          platform: 'macos',
+        },
+        actions: [
+          { type: 'mouse_click', timestamp: 0, x: 100, y: 100, button: 'left' },
+          { type: 'wait', timestamp: 1000 },
+        ],
+      };
+    }),
+    addEventListener: jest.fn((eventType: string, listener: (event: IPCEvent) => void) => {
+      if (!eventListeners.has(eventType)) {
+        eventListeners.set(eventType, []);
+      }
+      eventListeners.get(eventType)!.push(listener);
+    }),
+    removeEventListener: jest.fn((eventType: string, listener: (event: IPCEvent) => void) => {
+      const listeners = eventListeners.get(eventType);
+      if (listeners) {
+        const index = listeners.indexOf(listener);
+        if (index !== -1) {
+          listeners.splice(index, 1);
+        }
+      }
+    }),
+  };
+
+  (getIPCBridge as jest.MockedFunction<typeof getIPCBridge>).mockReturnValue(mockIPCBridge);
+
+  return { mockIPCBridge, eventListeners };
+}
+
+/**
+ * Emit IPC event to listeners
+ */
+function emitIPCEvent(
+  eventListeners: Map<string, ((event: IPCEvent) => void)[]>,
+  eventType: string,
+  data: any
+) {
+  const listeners = eventListeners.get(eventType) || [];
+  listeners.forEach(listener => listener({ type: eventType as any, data }));
+}
+
+// ============================================================================
+// Property Tests
+// ============================================================================
+
+describe('AI Script Playback Compatibility Property Tests', () => {
+  let playbackService: PlaybackService;
+  let mockIPCBridge: any;
+  let eventListeners: Map<string, ((event: IPCEvent) => void)[]>;
+
+  /**
+   * Build a completely fresh, ISOLATED playback service + mock IPC bridge and
+   * return them as locals.
+   *
+   * IMPORTANT: fast-check executes each property body many times. Reusing a
+   * singleton across runs leaks state (isPlaying flag, accumulated callbacks,
+   * currentScript). Worse, mutating a single suite-level `playbackService` /
+   * `eventListeners` per run is racy across `await` points: a callback may be
+   * registered on instance A but events get emitted to instance B.
+   *
+   * Each property run captures its own locals from this helper and uses them
+   * exclusively. The suite-level vars are kept in sync only for the handful of
+   * fully-synchronous tests that still read them.
+   */
+  function freshPlayback() {
+    resetPlaybackService();
+    resetIPCBridge();
+    const setup = setupMockIPCBridge();
+    // Construct the service DIRECTLY (not via the module singleton) so each run
+    // owns a private instance bound to its own mock bridge — immune to the
+    // shared global singleton being reset by a subsequent property run.
+    const service = new PlaybackService();
+    mockIPCBridge = setup.mockIPCBridge;
+    eventListeners = setup.eventListeners;
+    playbackService = service;
+    return { service, listeners: setup.eventListeners, bridge: setup.mockIPCBridge };
+  }
+
+  beforeEach(() => {
+    freshPlayback();
+  });
+
+  afterEach(() => {
+    resetPlaybackService();
+    resetIPCBridge();
+  });
+
+  /**
+   * **Feature: ai-script-builder, Property 17: AI Script Playback Compatibility**
+   * **Validates: Requirements 9.3**
+   * 
+   * For any AI-generated script, selecting it in the Recorder should load it
+   * with the same playback controls as recorded scripts.
+   */
+  describe('Property 17: AI Script Playback Compatibility', () => {
+    it('AI-generated scripts have the same playback capabilities as recorded scripts', async () => {
+      await fc.assert(
+        fc.property(
+          aiGeneratedScriptArbitrary,
+          recordedScriptArbitrary,
+          (aiScript, recordedScript) => {
+            const aiCapabilities = getPlaybackCapabilities(aiScript);
+            const recordedCapabilities = getPlaybackCapabilities(recordedScript);
+
+            return haveSamePlaybackCapabilities(aiCapabilities, recordedCapabilities);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('AI-generated scripts can be started with playback service', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          aiGeneratedScriptArbitrary,
+          scriptNameArbitrary,
+          targetOSArbitrary,
+          async (script, scriptName, targetOS) => {
+            // Fresh, isolated instance for THIS run. Alias to body-local consts so
+            // any interleaving across awaits cannot swap the instance mid-run.
+            const { service: playbackService, listeners: eventListeners, bridge: mockIPCBridge } = freshPlayback();
+            // Prepare script for save (adds AI metadata)
+            const preparedScript = prepareScriptForSave(script, scriptName, targetOS);
+
+            // Verify it's an AI-generated script
+            if (!isAIGeneratedScript(preparedScript)) {
+              return false;
+            }
+
+            // Mock script path
+            const scriptPath = `/path/to/${scriptName}.json`;
+
+            // Try to start playback
+            try {
+              await playbackService.startPlayback(scriptPath);
+
+              // Verify playback was started
+              const status = playbackService.getStatus();
+              return status.isPlaying && status.currentScript === scriptPath;
+            } catch (error) {
+              return false;
+            }
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('AI-generated scripts support stop control', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          aiGeneratedScriptArbitrary,
+          scriptNameArbitrary,
+          async (script, scriptName) => {
+            // Fresh, isolated instance for THIS run. Alias to body-local consts so
+            // any interleaving across awaits cannot swap the instance mid-run.
+            const { service: playbackService, listeners: eventListeners, bridge: mockIPCBridge } = freshPlayback();
+            const scriptPath = `/path/to/${scriptName}.json`;
+
+            // Start playback
+            await playbackService.startPlayback(scriptPath);
+
+            // Stop playback
+            try {
+              await playbackService.stopPlayback();
+
+              // Emit stop event
+              emitIPCEvent(eventListeners, 'playback_stopped', {});
+
+              // Verify playback was stopped
+              const status = playbackService.getStatus();
+              return !status.isPlaying && status.currentScript === undefined;
+            } catch (error) {
+              return false;
+            }
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('AI-generated scripts support pause/resume control', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          aiGeneratedScriptArbitrary,
+          scriptNameArbitrary,
+          async (script, scriptName) => {
+            // Fresh, isolated instance for THIS run. Alias to body-local consts so
+            // any interleaving across awaits cannot swap the instance mid-run.
+            const { service: playbackService, listeners: eventListeners, bridge: mockIPCBridge } = freshPlayback();
+            const scriptPath = `/path/to/${scriptName}.json`;
+
+            // Start playback
+            await playbackService.startPlayback(scriptPath);
+
+            // Pause playback
+            mockIPCBridge.pausePlayback.mockResolvedValue(true);
+            const isPaused = await playbackService.togglePause();
+
+            if (!isPaused) {
+              return false;
+            }
+
+            // Resume playback
+            mockIPCBridge.pausePlayback.mockResolvedValue(false);
+            const isResumed = await playbackService.togglePause();
+
+            return !isResumed;
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('AI-generated scripts support progress tracking', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          aiGeneratedScriptArbitrary,
+          scriptNameArbitrary,
+          async (script, scriptName) => {
+            // Fresh, isolated instance for THIS run. Alias to body-local consts so
+            // any interleaving across awaits cannot swap the instance mid-run.
+            const { service: playbackService, listeners: eventListeners, bridge: mockIPCBridge } = freshPlayback();
+            const scriptPath = `/path/to/${scriptName}.json`;
+
+            // Setup progress callback
+            let progressReceived = false;
+            playbackService.onProgress((progress) => {
+              progressReceived = true;
+            });
+
+            // Start playback
+            await playbackService.startPlayback(scriptPath);
+
+            // Emit progress event
+            emitIPCEvent(eventListeners, 'progress', {
+              currentAction: 1,
+              totalActions: script.actions.length,
+              currentLoop: 1,
+              totalLoops: 1,
+            });
+
+            return progressReceived;
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('AI-generated scripts support error handling', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          aiGeneratedScriptArbitrary,
+          scriptNameArbitrary,
+          fc.string({ minLength: 5, maxLength: 50 }),
+          async (script, scriptName, errorMessage) => {
+            // Fresh, isolated instance for THIS run. Alias to body-local consts so
+            // any interleaving across awaits cannot swap the instance mid-run.
+            const { service: playbackService, listeners: eventListeners, bridge: mockIPCBridge } = freshPlayback();
+            const scriptPath = `/path/to/${scriptName}.json`;
+
+            // Setup error callback
+            let errorReceived = false;
+            let receivedMessage = '';
+            playbackService.onError((error) => {
+              errorReceived = true;
+              receivedMessage = error;
+            });
+
+            // Start playback
+            await playbackService.startPlayback(scriptPath);
+
+            // Emit error event
+            emitIPCEvent(eventListeners, 'error', { message: errorMessage });
+
+            return errorReceived && receivedMessage === errorMessage;
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('AI-generated scripts support completion events', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          aiGeneratedScriptArbitrary,
+          scriptNameArbitrary,
+          async (script, scriptName) => {
+            // Fresh, isolated instance for THIS run. Alias to body-local consts so
+            // any interleaving across awaits cannot swap the instance mid-run.
+            const { service: playbackService, listeners: eventListeners, bridge: mockIPCBridge } = freshPlayback();
+            const scriptPath = `/path/to/${scriptName}.json`;
+
+            // Setup complete callback
+            let completeReceived = false;
+            playbackService.onComplete(() => {
+              completeReceived = true;
+            });
+
+            // Start playback
+            await playbackService.startPlayback(scriptPath);
+
+            // Emit complete event
+            emitIPCEvent(eventListeners, 'complete', {});
+
+            return completeReceived;
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('AI-generated scripts with different target OS all support playback', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          aiGeneratedScriptArbitrary,
+          scriptNameArbitrary,
+          async (script, scriptName) => {
+            // Fresh, isolated instance for THIS run. Alias to body-local consts so
+            // any interleaving across awaits cannot swap the instance mid-run.
+            const { service: playbackService, listeners: eventListeners, bridge: mockIPCBridge } = freshPlayback();
+            const targetOSValues: TargetOS[] = ['macos', 'windows', 'universal'];
+            const results: boolean[] = [];
+
+            for (const targetOS of targetOSValues) {
+              const preparedScript = prepareScriptForSave(script, scriptName, targetOS);
+              const scriptPath = `/path/to/${scriptName}_${targetOS}.json`;
+
+              try {
+                await playbackService.startPlayback(scriptPath);
+                const status = playbackService.getStatus();
+                results.push(status.isPlaying);
+
+                // Stop for next iteration
+                await playbackService.stopPlayback();
+                emitIPCEvent(eventListeners, 'playback_stopped', {});
+              } catch (error) {
+                results.push(false);
+              }
+            }
+
+            // All target OS variants should support playback
+            return results.every(result => result === true);
+          }
+        ),
+        { numRuns: 30 }
+      );
+    });
+
+    it('AI-generated scripts support playback options (speed, loop)', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          aiGeneratedScriptArbitrary,
+          scriptNameArbitrary,
+          fc.double({ min: 0.1, max: 10.0 }),
+          fc.integer({ min: 1, max: 5 }),
+          async (script, scriptName, speed, loopCount) => {
+            // Fresh, isolated instance for THIS run. Alias to body-local consts so
+            // any interleaving across awaits cannot swap the instance mid-run.
+            const { service: playbackService, listeners: eventListeners, bridge: mockIPCBridge } = freshPlayback();
+            const scriptPath = `/path/to/${scriptName}.json`;
+
+            try {
+              await playbackService.startPlayback(scriptPath, { speed, loopCount });
+
+              // Verify playback started with options
+              expect(mockIPCBridge.startPlayback).toHaveBeenCalledWith(
+                scriptPath,
+                speed,
+                loopCount
+              );
+
+              const status = playbackService.getStatus();
+              return status.isPlaying && status.progress?.totalLoops === loopCount;
+            } catch (error) {
+              return false;
+            }
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('playback capabilities are independent of script source', async () => {
+      await fc.assert(
+        fc.property(
+          aiGeneratedScriptArbitrary,
+          recordedScriptArbitrary,
+          (aiScript, recordedScript) => {
+            // Both scripts should have identical playback capabilities
+            const aiCaps = getPlaybackCapabilities(aiScript);
+            const recordedCaps = getPlaybackCapabilities(recordedScript);
+
+            // All capabilities should match
+            return (
+              aiCaps.canStart === recordedCaps.canStart &&
+              aiCaps.canStop === recordedCaps.canStop &&
+              aiCaps.canPause === recordedCaps.canPause &&
+              aiCaps.canResume === recordedCaps.canResume &&
+              aiCaps.hasProgressTracking === recordedCaps.hasProgressTracking &&
+              aiCaps.hasErrorHandling === recordedCaps.hasErrorHandling
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('AI-generated scripts maintain playback state correctly', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          aiGeneratedScriptArbitrary,
+          scriptNameArbitrary,
+          async (script, scriptName) => {
+            // Fresh, isolated instance for THIS run. Alias to body-local consts so
+            // any interleaving across awaits cannot swap the instance mid-run.
+            const { service: playbackService, listeners: eventListeners, bridge: mockIPCBridge } = freshPlayback();
+            const scriptPath = `/path/to/${scriptName}.json`;
+
+            // Initial state: not playing
+            let status = playbackService.getStatus();
+            if (status.isPlaying) {
+              return false;
+            }
+
+            // Start playback
+            await playbackService.startPlayback(scriptPath);
+            status = playbackService.getStatus();
+            if (!status.isPlaying || status.currentScript !== scriptPath) {
+              return false;
+            }
+
+            // Pause
+            mockIPCBridge.pausePlayback.mockResolvedValue(true);
+            await playbackService.togglePause();
+            status = playbackService.getStatus();
+            if (!status.isPaused) {
+              return false;
+            }
+
+            // Resume
+            mockIPCBridge.pausePlayback.mockResolvedValue(false);
+            await playbackService.togglePause();
+            status = playbackService.getStatus();
+            if (status.isPaused) {
+              return false;
+            }
+
+            // Stop
+            await playbackService.stopPlayback();
+            emitIPCEvent(eventListeners, 'playback_stopped', {});
+            status = playbackService.getStatus();
+            if (status.isPlaying || status.currentScript !== undefined) {
+              return false;
+            }
+
+            return true;
+          }
+        ),
+        { numRuns: 30 }
+      );
+    });
+
+    it('AI-generated scripts with varying action counts all support playback', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 1, max: 100 }),
+          scriptNameArbitrary,
+          async (actionCount, scriptName) => {
+            // Fresh, isolated instance for THIS run. Alias to body-local consts so
+            // any interleaving across awaits cannot swap the instance mid-run.
+            const { service: playbackService, listeners: eventListeners, bridge: mockIPCBridge } = freshPlayback();
+            // Create script with specific action count
+            const actions: Action[] = Array.from({ length: actionCount }, (_, i) => ({
+              type: 'mouse_click' as const,
+              timestamp: i * 100,
+              x: 100 + i,
+              y: 100 + i,
+              button: 'left' as const,
+            }));
+
+            const script: ScriptData = {
+              version: '1.0',
+              metadata: {
+                created_at: new Date().toISOString(),
+                duration: actions[actions.length - 1].timestamp,
+                action_count: actions.length,
+                core_type: 'rust',
+                platform: 'macos',
+                additional_data: {
+                  source: 'ai_generated',
+                  generated_at: new Date().toISOString(),
+                  generated_by: 'ai_script_builder',
+                },
+              },
+              actions,
+            };
+
+            const scriptPath = `/path/to/${scriptName}.json`;
+
+            try {
+              await playbackService.startPlayback(scriptPath);
+              const status = playbackService.getStatus();
+              return status.isPlaying;
+            } catch (error) {
+              return false;
+            }
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('AI-generated scripts support all action types in playback', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          actionTypeArbitrary,
+          scriptNameArbitrary,
+          async (actionType, scriptName) => {
+            // Fresh, isolated instance for THIS run. Alias to body-local consts so
+            // any interleaving across awaits cannot swap the instance mid-run.
+            const { service: playbackService, listeners: eventListeners, bridge: mockIPCBridge } = freshPlayback();
+            // Create script with single action of given type
+            const action: Action = {
+              type: actionType,
+              timestamp: 0,
+              ...(actionType.startsWith('mouse') ? { x: 100, y: 100 } : {}),
+              ...(actionType === 'mouse_click' ? { button: 'left' as const } : {}),
+              ...(actionType === 'key_press' ? { key: 'a' } : {}),
+              ...(actionType === 'key_type' ? { text: 'test' } : {}),
+            };
+
+            const script: ScriptData = {
+              version: '1.0',
+              metadata: {
+                created_at: new Date().toISOString(),
+                duration: 0,
+                action_count: 1,
+                core_type: 'rust',
+                platform: 'macos',
+                additional_data: {
+                  source: 'ai_generated',
+                  generated_at: new Date().toISOString(),
+                  generated_by: 'ai_script_builder',
+                },
+              },
+              actions: [action],
+            };
+
+            const scriptPath = `/path/to/${scriptName}.json`;
+
+            try {
+              await playbackService.startPlayback(scriptPath);
+              const status = playbackService.getStatus();
+              return status.isPlaying;
+            } catch (error) {
+              return false;
+            }
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  /**
+   * Edge cases and boundary conditions
+   */
+  describe('Edge Cases and Boundary Conditions', () => {
+    it('handles AI-generated script with single action', async () => {
+      const script: ScriptData = {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration: 0,
+          action_count: 1,
+          core_type: 'rust',
+          platform: 'macos',
+          additional_data: {
+            source: 'ai_generated',
+            generated_at: new Date().toISOString(),
+            generated_by: 'ai_script_builder',
+          },
+        },
+        actions: [{
+          type: 'mouse_click',
+          timestamp: 0,
+          x: 100,
+          y: 100,
+          button: 'left',
+        }],
+      };
+
+      const capabilities = getPlaybackCapabilities(script);
+      expect(capabilities.canStart).toBe(true);
+      expect(capabilities.canStop).toBe(true);
+      expect(capabilities.canPause).toBe(true);
+    });
+
+    it('handles AI-generated script with many actions', async () => {
+      const actions: Action[] = Array.from({ length: 100 }, (_, i) => ({
+        type: 'mouse_click' as const,
+        timestamp: i * 10,
+        x: 100 + i,
+        y: 100 + i,
+        button: 'left' as const,
+      }));
+
+      const script: ScriptData = {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration: 990,
+          action_count: 100,
+          core_type: 'rust',
+          platform: 'macos',
+          additional_data: {
+            source: 'ai_generated',
+            generated_at: new Date().toISOString(),
+            generated_by: 'ai_script_builder',
+          },
+        },
+        actions,
+      };
+
+      const capabilities = getPlaybackCapabilities(script);
+      expect(capabilities.canStart).toBe(true);
+      expect(capabilities.hasProgressTracking).toBe(true);
+    });
+
+    it('AI and recorded scripts with same structure have identical capabilities', async () => {
+      const actions: Action[] = [
+        { type: 'mouse_click', timestamp: 0, x: 100, y: 100, button: 'left' },
+        { type: 'key_type', timestamp: 500, text: 'test' },
+        { type: 'wait', timestamp: 1000 },
+      ];
+
+      const aiScript: ScriptData = {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration: 1000,
+          action_count: 3,
+          core_type: 'rust',
+          platform: 'macos',
+          additional_data: {
+            source: 'ai_generated',
+            generated_at: new Date().toISOString(),
+            generated_by: 'ai_script_builder',
+          },
+        },
+        actions,
+      };
+
+      const recordedScript: ScriptData = {
+        version: '1.0',
+        metadata: {
+          created_at: new Date().toISOString(),
+          duration: 1000,
+          action_count: 3,
+          core_type: 'rust',
+          platform: 'macos',
+          additional_data: {
+            source: 'recorded',
+          },
+        },
+        actions,
+      };
+
+      const aiCaps = getPlaybackCapabilities(aiScript);
+      const recordedCaps = getPlaybackCapabilities(recordedScript);
+
+      expect(haveSamePlaybackCapabilities(aiCaps, recordedCaps)).toBe(true);
+    });
+
+    it('handles playback service state transitions correctly', async () => {
+      const scriptPath = '/path/to/test.json';
+
+      // Start
+      await playbackService.startPlayback(scriptPath);
+      expect(playbackService.getStatus().isPlaying).toBe(true);
+
+      // Pause
+      mockIPCBridge.pausePlayback.mockResolvedValue(true);
+      await playbackService.togglePause();
+      expect(playbackService.getStatus().isPaused).toBe(true);
+
+      // Resume
+      mockIPCBridge.pausePlayback.mockResolvedValue(false);
+      await playbackService.togglePause();
+      expect(playbackService.getStatus().isPaused).toBe(false);
+
+      // Stop
+      await playbackService.stopPlayback();
+      emitIPCEvent(eventListeners, 'playback_stopped', {});
+      expect(playbackService.getStatus().isPlaying).toBe(false);
+    });
+  });
+});

--- a/packages/desktop/src/services/__tests__/firebaseService.test.ts
+++ b/packages/desktop/src/services/__tests__/firebaseService.test.ts
@@ -1,273 +1,184 @@
 /**
- * Unit tests for Firebase Authentication Service
+ * Unit tests for Firebase Authentication Service (Firebase Web SDK / Tauri)
+ *
+ * The service under test uses the Firebase Web SDK (`firebase/auth`), NOT the
+ * React Native Firebase packages. These tests mock the Web SDK functions and
+ * the supporting modules (config, oauthService, env util).
  */
 
-// Mock the env utility first
-jest.mock('../../../utils/env', () => ({
-  getEnvVar: jest.fn((key, fallback) => {
-    const mockEnv = {
-      VITE_FIREBASE_API_KEY: 'test-api-key',
-      VITE_FIREBASE_AUTH_DOMAIN: 'test-auth-domain',
-      VITE_FIREBASE_PROJECT_ID: 'test-project-id',
-      VITE_FIREBASE_STORAGE_BUCKET: 'test-storage-bucket',
-      VITE_FIREBASE_MESSAGING_SENDER_ID: 'test-sender-id',
-      VITE_FIREBASE_APP_ID: 'test-app-id',
-      VITE_GOOGLE_WEB_CLIENT_ID: 'test-google-client-id'
+// --- Mocks must be declared before importing the service under test ---
+
+// env util lives at src/utils/env (two levels up from this __tests__ dir).
+// It uses import.meta.env which Jest cannot parse, so it must be mocked.
+jest.mock('../../utils/env', () => ({
+  getEnvVar: jest.fn((key: string, fallback?: string) => {
+    const mockEnv: Record<string, string> = {
+      GOOGLE_CLIENT_ID: 'test-google-client-id',
+      VITE_GOOGLE_CLIENT_ID: 'test-google-client-id',
     };
-    const viteKey = key.startsWith('VITE_') ? key : `VITE_${key}`;
-    return mockEnv[viteKey] || fallback || '';
+    return mockEnv[key] ?? fallback ?? '';
   }),
-  getRequiredEnvVar: jest.fn((key) => {
-    const mockEnv = {
-      VITE_FIREBASE_API_KEY: 'test-api-key',
-      VITE_FIREBASE_AUTH_DOMAIN: 'test-auth-domain',
-      VITE_FIREBASE_PROJECT_ID: 'test-project-id',
-      VITE_FIREBASE_STORAGE_BUCKET: 'test-storage-bucket',
-      VITE_FIREBASE_MESSAGING_SENDER_ID: 'test-sender-id',
-      VITE_FIREBASE_APP_ID: 'test-app-id',
-      VITE_GOOGLE_WEB_CLIENT_ID: 'test-google-client-id'
-    };
-    const viteKey = key.startsWith('VITE_') ? key : `VITE_${key}`;
-    return mockEnv[viteKey] || 'test-value';
-  })
+  getRequiredEnvVar: jest.fn((key: string) => key),
+  hasEnvVar: jest.fn(() => true),
 }));
 
-// Mock Firebase modules
-jest.mock('firebase/app', () => ({
-  initializeApp: jest.fn(() => ({ name: 'test-app' }))
+// Firebase config — avoid real Firebase initialization.
+jest.mock('../../config/firebase.config', () => ({
+  app: { name: 'test-app' },
 }));
 
-jest.mock('firebase/auth', () => ({
-  getAuth: jest.fn(() => ({
-    currentUser: null,
+// oauthService used by Google sign-in helpers.
+jest.mock('../oauthService', () => ({
+  __esModule: true,
+  default: {
+    generateGoogleOAuthUrl: jest.fn(() => 'https://accounts.google.com/o/oauth2/auth?test'),
+    openOAuthInBrowser: jest.fn(async () => undefined),
+  },
+}));
+
+// Firebase Web SDK auth functions.
+// The mock auth instance must be created INSIDE the factory because jest.mock
+// is hoisted above all module-scope declarations; we read it back after import.
+jest.mock('firebase/auth', () => {
+  const authInstance = { currentUser: null as any };
+  return {
+    __mockAuthInstance: authInstance,
+    getAuth: jest.fn(() => authInstance),
     signInWithEmailAndPassword: jest.fn(),
     createUserWithEmailAndPassword: jest.fn(),
+    signInWithPopup: jest.fn(),
     signInWithCredential: jest.fn(),
     signOut: jest.fn(),
-    onAuthStateChanged: jest.fn()
-  })),
-  GoogleAuthProvider: jest.fn().mockImplementation(() => ({
-    credential: jest.fn()
-  }))
-}));
+    onAuthStateChanged: jest.fn(),
+    GoogleAuthProvider: class {
+      static credential = jest.fn((idToken: string) => ({ idToken, providerId: 'google.com' }));
+    },
+  };
+});
+
+// This suite runs under the "services" jest project (testEnvironment: node),
+// so localStorage is not provided by the runtime — supply a minimal polyfill
+// because signOut() calls localStorage.clear().
+const localStoragePolyfill = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => {
+      store[k] = String(v);
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+(globalThis as any).localStorage = localStoragePolyfill;
 
 import firebaseService from '../firebaseService';
-import auth from '@react-native-firebase/auth';
-import { GoogleSignin } from '@react-native-google-signin/google-signin';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as firebaseAuth from 'firebase/auth';
+import oauthService from '../oauthService';
 
-// Mock Firebase Auth
-jest.mock('@react-native-firebase/auth');
-jest.mock('@react-native-google-signin/google-signin');
-jest.mock('@react-native-async-storage/async-storage');
+const mockedAuth = firebaseAuth as jest.Mocked<typeof firebaseAuth>;
+const mockAuthInstance = (firebaseAuth as any).__mockAuthInstance as { currentUser: any };
 
-describe('FirebaseAuthService', () => {
+describe('FirebaseAuthService (Web SDK)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAuthInstance.currentUser = null;
+    localStorage.clear();
   });
 
   describe('initialize', () => {
-    it('should configure Google Sign-In successfully', async () => {
-      await firebaseService.initialize();
-      
-      expect(GoogleSignin.configure).toHaveBeenCalledWith({
-        webClientId: expect.any(String),
-      });
-    });
-
-    it('should not reinitialize if already initialized', async () => {
-      await firebaseService.initialize();
-      await firebaseService.initialize();
-      
-      expect(GoogleSignin.configure).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('signInWithEmail', () => {
-    it('should sign in successfully with valid credentials', async () => {
-      const mockUserCredential = {
-        user: { uid: '123', email: 'test@example.com' },
-      };
-      
-      (auth as any).mockReturnValue({
-        signInWithEmailAndPassword: jest.fn().mockResolvedValue(mockUserCredential),
-      });
-
-      const result = await firebaseService.signInWithEmail('test@example.com', 'password123');
-      
-      expect(result).toEqual(mockUserCredential);
-    });
-
-    it('should throw error with invalid credentials', async () => {
-      const mockError = { code: 'auth/wrong-password' };
-      
-      (auth as any).mockReturnValue({
-        signInWithEmailAndPassword: jest.fn().mockRejectedValue(mockError),
-      });
-
-      await expect(
-        firebaseService.signInWithEmail('test@example.com', 'wrongpassword')
-      ).rejects.toThrow();
-    });
-
-    it('should throw error with invalid email format', async () => {
-      const mockError = { code: 'auth/invalid-email' };
-      
-      (auth as any).mockReturnValue({
-        signInWithEmailAndPassword: jest.fn().mockRejectedValue(mockError),
-      });
-
-      await expect(
-        firebaseService.signInWithEmail('invalid-email', 'password123')
-      ).rejects.toThrow();
-    });
-  });
-
-  describe('signUpWithEmail', () => {
-    it('should create account successfully with valid data', async () => {
-      const mockUserCredential = {
-        user: { uid: '456', email: 'newuser@example.com' },
-      };
-      
-      (auth as any).mockReturnValue({
-        createUserWithEmailAndPassword: jest.fn().mockResolvedValue(mockUserCredential),
-      });
-
-      const result = await firebaseService.signUpWithEmail('newuser@example.com', 'password123');
-      
-      expect(result).toEqual(mockUserCredential);
-    });
-
-    it('should throw error when email already exists', async () => {
-      const mockError = { code: 'auth/email-already-in-use' };
-      
-      (auth as any).mockReturnValue({
-        createUserWithEmailAndPassword: jest.fn().mockRejectedValue(mockError),
-      });
-
-      await expect(
-        firebaseService.signUpWithEmail('existing@example.com', 'password123')
-      ).rejects.toThrow();
-    });
-
-    it('should throw error with weak password', async () => {
-      const mockError = { code: 'auth/weak-password' };
-      
-      (auth as any).mockReturnValue({
-        createUserWithEmailAndPassword: jest.fn().mockRejectedValue(mockError),
-      });
-
-      await expect(
-        firebaseService.signUpWithEmail('test@example.com', '123')
-      ).rejects.toThrow();
-    });
-  });
-
-  describe('signInWithGoogle', () => {
-    it('should sign in successfully with Google', async () => {
-      const mockIdToken = 'mock-id-token';
-      const mockCredential = { token: 'mock-credential' };
-      const mockUserCredential = {
-        user: { uid: '789', email: 'google@example.com' },
-      };
-
-      (GoogleSignin.hasPlayServices as jest.Mock).mockResolvedValue(true);
-      (GoogleSignin.signIn as jest.Mock).mockResolvedValue({ idToken: mockIdToken });
-      (auth.GoogleAuthProvider.credential as jest.Mock).mockReturnValue(mockCredential);
-      (auth as any).mockReturnValue({
-        signInWithCredential: jest.fn().mockResolvedValue(mockUserCredential),
-      });
-
-      const result = await firebaseService.signInWithGoogle();
-      
-      expect(GoogleSignin.hasPlayServices).toHaveBeenCalled();
-      expect(GoogleSignin.signIn).toHaveBeenCalled();
-      expect(result).toEqual(mockUserCredential);
-    });
-
-    it('should throw error when sign in is cancelled', async () => {
-      const mockError = { code: 'SIGN_IN_CANCELLED' };
-
-      (GoogleSignin.hasPlayServices as jest.Mock).mockResolvedValue(true);
-      (GoogleSignin.signIn as jest.Mock).mockRejectedValue(mockError);
-
-      await expect(firebaseService.signInWithGoogle()).rejects.toThrow();
-    });
-
-    it('should throw error when Play Services not available', async () => {
-      const mockError = { code: 'PLAY_SERVICES_NOT_AVAILABLE' };
-
-      (GoogleSignin.hasPlayServices as jest.Mock).mockRejectedValue(mockError);
-
-      await expect(firebaseService.signInWithGoogle()).rejects.toThrow();
-    });
-  });
-
-  describe('signOut', () => {
-    it('should sign out successfully', async () => {
-      (GoogleSignin.isSignedIn as jest.Mock).mockResolvedValue(true);
-      (GoogleSignin.signOut as jest.Mock).mockResolvedValue(undefined);
-      (auth as any).mockReturnValue({
-        signOut: jest.fn().mockResolvedValue(undefined),
-      });
-      (AsyncStorage.clear as jest.Mock).mockResolvedValue(undefined);
-
-      await firebaseService.signOut();
-      
-      expect(GoogleSignin.signOut).toHaveBeenCalled();
-      expect(AsyncStorage.clear).toHaveBeenCalled();
-    });
-
-    it('should clear storage even if Google sign out fails', async () => {
-      (GoogleSignin.isSignedIn as jest.Mock).mockResolvedValue(false);
-      (auth as any).mockReturnValue({
-        signOut: jest.fn().mockResolvedValue(undefined),
-      });
-      (AsyncStorage.clear as jest.Mock).mockResolvedValue(undefined);
-
-      await firebaseService.signOut();
-      
-      expect(GoogleSignin.signOut).not.toHaveBeenCalled();
-      expect(AsyncStorage.clear).toHaveBeenCalled();
+    it('initializes successfully and is idempotent', async () => {
+      await expect(firebaseService.initialize()).resolves.toBeUndefined();
+      // Second call returns early without throwing
+      await expect(firebaseService.initialize()).resolves.toBeUndefined();
     });
   });
 
   describe('getCurrentUser', () => {
-    it('should return current user when authenticated', () => {
-      const mockUser = { uid: '123', email: 'test@example.com' };
-      (auth as any).mockReturnValue({
-        currentUser: mockUser,
-      });
-
-      const user = firebaseService.getCurrentUser();
-      
-      expect(user).toEqual(mockUser);
+    it('returns null when no user is signed in', () => {
+      expect(firebaseService.getCurrentUser()).toBeNull();
     });
 
-    it('should return null when not authenticated', () => {
-      (auth as any).mockReturnValue({
-        currentUser: null,
-      });
-
-      const user = firebaseService.getCurrentUser();
-      
-      expect(user).toBeNull();
+    it('returns the current Firebase user when signed in', () => {
+      const fakeUser = { uid: 'abc', email: 'a@b.com' };
+      mockAuthInstance.currentUser = fakeUser;
+      expect(firebaseService.getCurrentUser()).toBe(fakeUser);
     });
   });
 
   describe('onAuthStateChanged', () => {
-    it('should setup auth state listener', () => {
-      const mockCallback = jest.fn();
-      const mockUnsubscribe = jest.fn();
-      
-      (auth as any).mockReturnValue({
-        onAuthStateChanged: jest.fn().mockReturnValue(mockUnsubscribe),
-      });
+    it('registers a listener and returns the unsubscribe fn', () => {
+      const unsub = jest.fn();
+      mockedAuth.onAuthStateChanged.mockReturnValue(unsub as any);
+      const cb = jest.fn();
+      const result = firebaseService.onAuthStateChanged(cb);
+      expect(mockedAuth.onAuthStateChanged).toHaveBeenCalledWith(mockAuthInstance, cb);
+      expect(result).toBe(unsub);
+    });
+  });
 
-      const unsubscribe = firebaseService.onAuthStateChanged(mockCallback);
-      
-      expect(auth().onAuthStateChanged).toHaveBeenCalledWith(mockCallback);
-      expect(unsubscribe).toBe(mockUnsubscribe);
+  describe('signInWithEmail', () => {
+    it('returns the user credential on success', async () => {
+      const cred = { user: { uid: 'u1' } };
+      mockedAuth.signInWithEmailAndPassword.mockResolvedValue(cred as any);
+      await expect(firebaseService.signInWithEmail('a@b.com', 'pw')).resolves.toBe(cred);
+      expect(mockedAuth.signInWithEmailAndPassword).toHaveBeenCalledWith(
+        mockAuthInstance,
+        'a@b.com',
+        'pw'
+      );
+    });
+
+    it('throws a mapped error on failure', async () => {
+      mockedAuth.signInWithEmailAndPassword.mockRejectedValue({ code: 'auth/wrong-password' });
+      await expect(firebaseService.signInWithEmail('a@b.com', 'pw')).rejects.toThrow();
+    });
+  });
+
+  describe('signUpWithEmail', () => {
+    it('returns the user credential on success', async () => {
+      const cred = { user: { uid: 'u2' } };
+      mockedAuth.createUserWithEmailAndPassword.mockResolvedValue(cred as any);
+      await expect(firebaseService.signUpWithEmail('a@b.com', 'pw')).resolves.toBe(cred);
+    });
+
+    it('throws a mapped error on failure', async () => {
+      mockedAuth.createUserWithEmailAndPassword.mockRejectedValue({ code: 'auth/email-already-in-use' });
+      await expect(firebaseService.signUpWithEmail('a@b.com', 'pw')).rejects.toThrow();
+    });
+  });
+
+  describe('signInWithGoogleExternalBrowser', () => {
+    it('returns the generated OAuth URL', async () => {
+      const url = await firebaseService.signInWithGoogleExternalBrowser();
+      expect(url).toContain('accounts.google.com');
+      expect(oauthService.generateGoogleOAuthUrl).toHaveBeenCalledWith('test-google-client-id');
+      expect(oauthService.openOAuthInBrowser).toHaveBeenCalledWith(url);
+    });
+
+    it('still returns the URL if opening the browser fails', async () => {
+      (oauthService.openOAuthInBrowser as jest.Mock).mockRejectedValueOnce(new Error('no browser'));
+      const url = await firebaseService.signInWithGoogleExternalBrowser();
+      expect(url).toContain('accounts.google.com');
+    });
+  });
+
+  describe('signOut', () => {
+    it('signs out from Firebase and clears local storage', async () => {
+      mockedAuth.signOut.mockResolvedValue(undefined as any);
+      localStorage.setItem('foo', 'bar');
+      await firebaseService.signOut();
+      expect(mockedAuth.signOut).toHaveBeenCalledWith(mockAuthInstance);
+      expect(localStorage.getItem('foo')).toBeNull();
+    });
+
+    it('throws a mapped error on failure', async () => {
+      mockedAuth.signOut.mockRejectedValue({ code: 'auth/network-request-failed' });
+      await expect(firebaseService.signOut()).rejects.toThrow();
     });
   });
 });

--- a/packages/desktop/src/services/__tests__/ipcBridgeService.test.ts
+++ b/packages/desktop/src/services/__tests__/ipcBridgeService.test.ts
@@ -949,12 +949,16 @@ describe('IPCBridgeService', () => {
     });
 
     it('should format corrupted script file errors', async () => {
+      // startPlayback first calls getCoreStatus (for logging); mock it to succeed,
+      // then make the actual start_playback invoke fail.
+      mockInvoke.mockResolvedValueOnce({ activeCoreType: 'python', availableCores: ['python'] });
       mockInvoke.mockRejectedValueOnce(new Error('Script file corrupted: Invalid JSON format'));
 
       await expect(service.startPlayback()).rejects.toThrow('corrupted');
     });
 
     it('should format no recordings found errors', async () => {
+      mockInvoke.mockResolvedValueOnce({ activeCoreType: 'python', availableCores: ['python'] });
       mockInvoke.mockRejectedValueOnce(new Error('No recordings found'));
 
       await expect(service.startPlayback()).rejects.toThrow('No recordings found');
@@ -993,7 +997,8 @@ describe('IPCBridgeService', () => {
       const result1 = await service.stopRecording();
       expect(result1.success).toBe(false);
 
-      // Error 2: No recordings found
+      // Error 2: No recordings found (startPlayback calls getCoreStatus first)
+      mockInvoke.mockResolvedValueOnce({ activeCoreType: 'python', availableCores: ['python'] });
       mockInvoke.mockRejectedValueOnce(new Error('No recordings found'));
       await expect(service.startPlayback()).rejects.toThrow();
 

--- a/packages/desktop/src/services/__tests__/playbackService.test.ts
+++ b/packages/desktop/src/services/__tests__/playbackService.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Unit tests for PlaybackService
+ * 
+ * Tests the playback service's ability to control script playback,
+ * manage state, and handle event subscriptions.
+ * 
+ * Requirements: 7.5
+ */
+
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { IPCEvent } from '../../types/recorder.types';
+import { getIPCBridge, resetIPCBridge } from '../ipcBridgeService';
+import { PlaybackService, getPlaybackService, resetPlaybackService } from '../playbackService';
+
+// Mock the IPC bridge
+jest.mock('../ipcBridgeService');
+
+describe('PlaybackService', () => {
+  let playbackService: PlaybackService;
+  let mockIPCBridge: any;
+  let eventListeners: Map<string, ((event: IPCEvent) => void)[]>;
+
+  beforeEach(() => {
+    // Reset the service
+    resetPlaybackService();
+    resetIPCBridge();
+    
+    // Create event listeners map
+    eventListeners = new Map();
+    
+    // Create mock IPC bridge
+    mockIPCBridge = {
+      startPlayback: jest.fn().mockResolvedValue(undefined),
+      stopPlayback: jest.fn().mockResolvedValue(undefined),
+      pausePlayback: jest.fn().mockResolvedValue(false),
+      addEventListener: jest.fn((eventType: string, listener: (event: IPCEvent) => void) => {
+        if (!eventListeners.has(eventType)) {
+          eventListeners.set(eventType, []);
+        }
+        eventListeners.get(eventType)!.push(listener);
+      }),
+      removeEventListener: jest.fn((eventType: string, listener: (event: IPCEvent) => void) => {
+        const listeners = eventListeners.get(eventType);
+        if (listeners) {
+          const index = listeners.indexOf(listener);
+          if (index !== -1) {
+            listeners.splice(index, 1);
+          }
+        }
+      }),
+    };
+    
+    // Mock getIPCBridge to return our mock
+    (getIPCBridge as jest.MockedFunction<typeof getIPCBridge>).mockReturnValue(mockIPCBridge);
+    
+    // Create service instance
+    playbackService = new PlaybackService();
+  });
+
+  afterEach(() => {
+    resetPlaybackService();
+    resetIPCBridge();
+    jest.clearAllMocks();
+  });
+
+  // Helper function to emit IPC events
+  const emitIPCEvent = (eventType: string, data: any) => {
+    const listeners = eventListeners.get(eventType) || [];
+    listeners.forEach(listener => listener({ type: eventType as any, data }));
+  };
+
+  describe('startPlayback', () => {
+    it('should start playback with default options', async () => {
+      const scriptPath = '/path/to/script.json';
+      
+      await playbackService.startPlayback(scriptPath);
+      
+      expect(mockIPCBridge.startPlayback).toHaveBeenCalledWith(scriptPath, undefined, undefined);
+      
+      const status = playbackService.getStatus();
+      expect(status.isPlaying).toBe(true);
+      expect(status.isPaused).toBe(false);
+      expect(status.currentScript).toBe(scriptPath);
+    });
+
+    it('should start playback with custom speed and loop count', async () => {
+      const scriptPath = '/path/to/script.json';
+      const options = { speed: 2.0, loopCount: 3 };
+      
+      await playbackService.startPlayback(scriptPath, options);
+      
+      expect(mockIPCBridge.startPlayback).toHaveBeenCalledWith(scriptPath, 2.0, 3);
+      
+      const status = playbackService.getStatus();
+      expect(status.isPlaying).toBe(true);
+      expect(status.progress?.totalLoops).toBe(3);
+    });
+
+    it('should handle startPlayback errors', async () => {
+      const scriptPath = '/path/to/script.json';
+      const error = new Error('Failed to start playback');
+      mockIPCBridge.startPlayback.mockRejectedValue(error);
+      
+      await expect(playbackService.startPlayback(scriptPath)).rejects.toThrow('Failed to start playback');
+      
+      const status = playbackService.getStatus();
+      expect(status.isPlaying).toBe(false);
+      expect(status.currentScript).toBeUndefined();
+    });
+  });
+
+  describe('stopPlayback', () => {
+    it('should stop playback', async () => {
+      // Start playback first
+      await playbackService.startPlayback('/path/to/script.json');
+      
+      await playbackService.stopPlayback();
+      
+      expect(mockIPCBridge.stopPlayback).toHaveBeenCalled();
+    });
+
+    it('should reset state when playback_stopped event is received', async () => {
+      // Start playback
+      await playbackService.startPlayback('/path/to/script.json');
+      
+      // Emit playback_stopped event
+      emitIPCEvent('playback_stopped', {});
+      
+      const status = playbackService.getStatus();
+      expect(status.isPlaying).toBe(false);
+      expect(status.isPaused).toBe(false);
+      expect(status.currentScript).toBeUndefined();
+    });
+
+    it('should handle stopPlayback errors', async () => {
+      const error = new Error('Failed to stop playback');
+      mockIPCBridge.stopPlayback.mockRejectedValue(error);
+      
+      await expect(playbackService.stopPlayback()).rejects.toThrow('Failed to stop playback');
+      
+      // State should be reset even on error
+      const status = playbackService.getStatus();
+      expect(status.isPlaying).toBe(false);
+    });
+  });
+
+  describe('togglePause', () => {
+    it('should pause playback', async () => {
+      mockIPCBridge.pausePlayback.mockResolvedValue(true);
+      
+      const isPaused = await playbackService.togglePause();
+      
+      expect(mockIPCBridge.pausePlayback).toHaveBeenCalled();
+      expect(isPaused).toBe(true);
+      
+      const status = playbackService.getStatus();
+      expect(status.isPaused).toBe(true);
+    });
+
+    it('should resume playback', async () => {
+      // First pause
+      mockIPCBridge.pausePlayback.mockResolvedValue(true);
+      await playbackService.togglePause();
+      
+      // Then resume
+      mockIPCBridge.pausePlayback.mockResolvedValue(false);
+      const isPaused = await playbackService.togglePause();
+      
+      expect(isPaused).toBe(false);
+      
+      const status = playbackService.getStatus();
+      expect(status.isPaused).toBe(false);
+    });
+
+    it('should handle togglePause errors', async () => {
+      const error = new Error('Failed to toggle pause');
+      mockIPCBridge.pausePlayback.mockRejectedValue(error);
+      
+      await expect(playbackService.togglePause()).rejects.toThrow('Failed to toggle pause');
+    });
+  });
+
+  describe('progress events', () => {
+    it('should notify progress callbacks on progress event', async () => {
+      const progressCallback = jest.fn();
+      playbackService.onProgress(progressCallback);
+      
+      // Start playback
+      await playbackService.startPlayback('/path/to/script.json');
+      
+      // Emit progress event
+      emitIPCEvent('progress', {
+        currentAction: 5,
+        totalActions: 10,
+        currentLoop: 1,
+        totalLoops: 1,
+      });
+      
+      expect(progressCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currentAction: 5,
+          totalActions: 10,
+          currentLoop: 1,
+          totalLoops: 1,
+          status: 'playing',
+        })
+      );
+    });
+
+    it('should allow unsubscribing from progress events', async () => {
+      const progressCallback = jest.fn();
+      const unsubscribe = playbackService.onProgress(progressCallback);
+      
+      // Unsubscribe
+      unsubscribe();
+      
+      // Emit progress event
+      emitIPCEvent('progress', {
+        currentAction: 5,
+        totalActions: 10,
+        currentLoop: 1,
+        totalLoops: 1,
+      });
+      
+      expect(progressCallback).not.toHaveBeenCalled();
+    });
+
+    it('should handle multiple progress callbacks', async () => {
+      const callback1 = jest.fn();
+      const callback2 = jest.fn();
+      
+      playbackService.onProgress(callback1);
+      playbackService.onProgress(callback2);
+      
+      // Emit progress event
+      emitIPCEvent('progress', {
+        currentAction: 3,
+        totalActions: 10,
+        currentLoop: 1,
+        totalLoops: 1,
+      });
+      
+      expect(callback1).toHaveBeenCalled();
+      expect(callback2).toHaveBeenCalled();
+    });
+  });
+
+  describe('complete events', () => {
+    it('should notify complete callbacks on complete event', async () => {
+      const completeCallback = jest.fn();
+      playbackService.onComplete(completeCallback);
+      
+      // Start playback
+      await playbackService.startPlayback('/path/to/script.json');
+      
+      // Emit complete event
+      emitIPCEvent('complete', {});
+      
+      expect(completeCallback).toHaveBeenCalled();
+      
+      const status = playbackService.getStatus();
+      expect(status.isPlaying).toBe(false);
+      expect(status.currentScript).toBeUndefined();
+    });
+
+    it('should allow unsubscribing from complete events', async () => {
+      const completeCallback = jest.fn();
+      const unsubscribe = playbackService.onComplete(completeCallback);
+      
+      // Unsubscribe
+      unsubscribe();
+      
+      // Emit complete event
+      emitIPCEvent('complete', {});
+      
+      expect(completeCallback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error events', () => {
+    it('should notify error callbacks on error event', async () => {
+      const errorCallback = jest.fn();
+      playbackService.onError(errorCallback);
+      
+      // Start playback
+      await playbackService.startPlayback('/path/to/script.json');
+      
+      // Emit error event
+      emitIPCEvent('error', { message: 'Playback failed' });
+      
+      expect(errorCallback).toHaveBeenCalledWith('Playback failed');
+      
+      const status = playbackService.getStatus();
+      expect(status.isPlaying).toBe(false);
+      expect(status.currentScript).toBeUndefined();
+    });
+
+    it('should handle error event with error field', async () => {
+      const errorCallback = jest.fn();
+      playbackService.onError(errorCallback);
+      
+      // Emit error event with error field
+      emitIPCEvent('error', { error: 'Script not found' });
+      
+      expect(errorCallback).toHaveBeenCalledWith('Script not found');
+    });
+
+    it('should handle error event with no message', async () => {
+      const errorCallback = jest.fn();
+      playbackService.onError(errorCallback);
+      
+      // Emit error event with no message
+      emitIPCEvent('error', {});
+      
+      expect(errorCallback).toHaveBeenCalledWith('Unknown playback error');
+    });
+
+    it('should allow unsubscribing from error events', async () => {
+      const errorCallback = jest.fn();
+      const unsubscribe = playbackService.onError(errorCallback);
+      
+      // Unsubscribe
+      unsubscribe();
+      
+      // Emit error event
+      emitIPCEvent('error', { message: 'Playback failed' });
+      
+      expect(errorCallback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('playback_paused events', () => {
+    it('should update status on playback_paused event', async () => {
+      const progressCallback = jest.fn();
+      playbackService.onProgress(progressCallback);
+      
+      // Start playback
+      await playbackService.startPlayback('/path/to/script.json');
+      
+      // Set initial progress
+      emitIPCEvent('progress', {
+        currentAction: 5,
+        totalActions: 10,
+        currentLoop: 1,
+        totalLoops: 1,
+      });
+      
+      // Emit playback_paused event
+      emitIPCEvent('playback_paused', { is_paused: true });
+      
+      const status = playbackService.getStatus();
+      expect(status.isPaused).toBe(true);
+      expect(status.progress?.status).toBe('paused');
+      
+      // Progress callback should be called with updated status
+      expect(progressCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'paused',
+        })
+      );
+    });
+
+    it('should handle playback_paused event with isPaused field', async () => {
+      // Emit playback_paused event with isPaused field
+      emitIPCEvent('playback_paused', { isPaused: true });
+      
+      const status = playbackService.getStatus();
+      expect(status.isPaused).toBe(true);
+    });
+  });
+
+  describe('getStatus', () => {
+    it('should return idle status initially', () => {
+      const status = playbackService.getStatus();
+      
+      expect(status.isPlaying).toBe(false);
+      expect(status.isPaused).toBe(false);
+      expect(status.currentScript).toBeUndefined();
+      expect(status.progress).toBeUndefined();
+    });
+
+    it('should return playing status during playback', async () => {
+      await playbackService.startPlayback('/path/to/script.json');
+      
+      const status = playbackService.getStatus();
+      
+      expect(status.isPlaying).toBe(true);
+      expect(status.isPaused).toBe(false);
+      expect(status.currentScript).toBe('/path/to/script.json');
+      expect(status.progress).toBeDefined();
+    });
+
+    it('should return paused status when paused', async () => {
+      await playbackService.startPlayback('/path/to/script.json');
+      
+      mockIPCBridge.pausePlayback.mockResolvedValue(true);
+      await playbackService.togglePause();
+      
+      const status = playbackService.getStatus();
+      
+      expect(status.isPlaying).toBe(true);
+      expect(status.isPaused).toBe(true);
+    });
+  });
+
+  describe('singleton pattern', () => {
+    it('should return the same instance', () => {
+      const instance1 = getPlaybackService();
+      const instance2 = getPlaybackService();
+      
+      expect(instance1).toBe(instance2);
+    });
+
+    it('should create new instance after reset', () => {
+      const instance1 = getPlaybackService();
+      
+      resetPlaybackService();
+      
+      const instance2 = getPlaybackService();
+      
+      expect(instance1).not.toBe(instance2);
+    });
+  });
+
+  describe('error handling in callbacks', () => {
+    it('should handle errors in progress callbacks gracefully', async () => {
+      const errorCallback = jest.fn(() => {
+        throw new Error('Callback error');
+      });
+      const normalCallback = jest.fn();
+      
+      playbackService.onProgress(errorCallback);
+      playbackService.onProgress(normalCallback);
+      
+      // Emit progress event
+      emitIPCEvent('progress', {
+        currentAction: 5,
+        totalActions: 10,
+        currentLoop: 1,
+        totalLoops: 1,
+      });
+      
+      // Both callbacks should be called despite error in first one
+      expect(errorCallback).toHaveBeenCalled();
+      expect(normalCallback).toHaveBeenCalled();
+    });
+
+    it('should handle errors in complete callbacks gracefully', async () => {
+      const errorCallback = jest.fn(() => {
+        throw new Error('Callback error');
+      });
+      const normalCallback = jest.fn();
+      
+      playbackService.onComplete(errorCallback);
+      playbackService.onComplete(normalCallback);
+      
+      // Emit complete event
+      emitIPCEvent('complete', {});
+      
+      // Both callbacks should be called despite error in first one
+      expect(errorCallback).toHaveBeenCalled();
+      expect(normalCallback).toHaveBeenCalled();
+    });
+
+    it('should handle errors in error callbacks gracefully', async () => {
+      const errorCallback = jest.fn(() => {
+        throw new Error('Callback error');
+      });
+      const normalCallback = jest.fn();
+      
+      playbackService.onError(errorCallback);
+      playbackService.onError(normalCallback);
+      
+      // Emit error event
+      emitIPCEvent('error', { message: 'Playback failed' });
+      
+      // Both callbacks should be called despite error in first one
+      expect(errorCallback).toHaveBeenCalled();
+      expect(normalCallback).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/desktop/src/services/__tests__/scriptFilterCorrectness.property.test.ts
+++ b/packages/desktop/src/services/__tests__/scriptFilterCorrectness.property.test.ts
@@ -1,0 +1,1043 @@
+/**
+ * Property-Based Tests for Script Filter Correctness
+ * 
+ * Tests that script filtering works correctly for all filter combinations.
+ * For any filter selection (recorded, AI-generated, all), the filtered list
+ * should contain only scripts matching the filter criteria.
+ * 
+ * **Feature: ai-script-builder, Property 16: Script Filter Correctness**
+ * **Validates: Requirements 9.4**
+ */
+
+import * as fc from 'fast-check';
+import {
+    ScriptSource,
+    StoredScriptInfo,
+    TargetOS
+} from '../scriptStorageService';
+
+// ============================================================================
+// Arbitraries (Generators)
+// ============================================================================
+
+/**
+ * Generate a valid script source type
+ */
+const scriptSourceArbitrary: fc.Arbitrary<ScriptSource> = fc.constantFrom(
+  'recorded',
+  'ai_generated'
+);
+
+/**
+ * Generate a valid target OS
+ */
+const targetOSArbitrary: fc.Arbitrary<TargetOS> = fc.constantFrom(
+  'macos',
+  'windows',
+  'universal'
+);
+
+/**
+ * Generate a valid script filename
+ */
+const scriptFilenameArbitrary = (source: ScriptSource): fc.Arbitrary<string> => {
+  if (source === 'ai_generated') {
+    return fc.tuple(
+      fc.string({ minLength: 5, maxLength: 30 }),
+      fc.integer({ min: 1000000000000, max: 9999999999999 })
+    ).map(([name, timestamp]) =>
+      `ai_script_${name.replace(/[^a-z0-9_-]/gi, '_')}_${timestamp}.json`
+    );
+  } else {
+    return fc.tuple(
+      fc.string({ minLength: 5, maxLength: 30 }),
+      fc.integer({ min: 1000000000000, max: 9999999999999 })
+    ).map(([name, timestamp]) =>
+      `recording_${name.replace(/[^a-z0-9_-]/gi, '_')}_${timestamp}.json`
+    );
+  }
+};
+
+/**
+ * Generate a valid script name (for AI-generated scripts)
+ */
+const scriptNameArbitrary: fc.Arbitrary<string> = fc.oneof(
+  fc.string({ minLength: 5, maxLength: 50 })
+    .filter(s => s.trim().length >= 5)
+    .map(s => s.replace(/[^a-zA-Z0-9_\-\s]/g, '')),
+  fc.constantFrom(
+    'Login Test',
+    'Navigation Flow',
+    'Form Submission',
+    'Data Entry Script',
+    'UI Automation Test'
+  )
+);
+
+/**
+ * Generate a recorded script info
+ */
+const recordedScriptArbitrary: fc.Arbitrary<StoredScriptInfo> = fc.record({
+  filename: scriptFilenameArbitrary('recorded'),
+  path: fc.string({ minLength: 10, maxLength: 100 })
+    .map(p => `/home/user/GeniusQA/recordings/${p}.json`),
+  createdAt: fc.integer({ min: new Date('2020-01-01').getTime(), max: new Date('2030-12-31').getTime() })
+    .map(timestamp => new Date(timestamp).toISOString()),
+  duration: fc.integer({ min: 1, max: 300 }),
+  actionCount: fc.integer({ min: 1, max: 100 }),
+  source: fc.constant('recorded' as const),
+});
+
+/**
+ * Generate an AI-generated script info
+ */
+const aiGeneratedScriptArbitrary: fc.Arbitrary<StoredScriptInfo> = fc.record({
+  filename: scriptFilenameArbitrary('ai_generated'),
+  path: fc.string({ minLength: 10, maxLength: 100 })
+    .map(p => `/home/user/GeniusQA/recordings/${p}.json`),
+  createdAt: fc.integer({ min: new Date('2020-01-01').getTime(), max: new Date('2030-12-31').getTime() })
+    .map(timestamp => new Date(timestamp).toISOString()),
+  duration: fc.integer({ min: 1, max: 300 }),
+  actionCount: fc.integer({ min: 1, max: 100 }),
+  source: fc.constant('ai_generated' as const),
+  targetOS: targetOSArbitrary,
+  scriptName: scriptNameArbitrary,
+});
+
+/**
+ * Generate a script info (either recorded or AI-generated)
+ */
+const scriptInfoArbitrary: fc.Arbitrary<StoredScriptInfo> = fc.oneof(
+  recordedScriptArbitrary,
+  aiGeneratedScriptArbitrary
+);
+
+/**
+ * Generate a combination of recorded and AI-generated scripts
+ */
+const scriptCombinationArbitrary: fc.Arbitrary<StoredScriptInfo[]> = fc.record({
+  recordedCount: fc.integer({ min: 0, max: 10 }),
+  aiGeneratedCount: fc.integer({ min: 0, max: 10 }),
+}).chain(({ recordedCount, aiGeneratedCount }) => {
+  return fc.tuple(
+    fc.array(recordedScriptArbitrary, { minLength: recordedCount, maxLength: recordedCount }),
+    fc.array(aiGeneratedScriptArbitrary, { minLength: aiGeneratedCount, maxLength: aiGeneratedCount })
+  ).map(([recorded, aiGenerated]) => [...recorded, ...aiGenerated]);
+});
+
+/**
+ * Generate a valid script filter
+ */
+const scriptFilterArbitrary: fc.Arbitrary<ScriptFilter> = fc.record({
+  source: fc.option(
+    fc.constantFrom('all' as const, 'recorded' as const, 'ai_generated' as const),
+    { nil: undefined }
+  ),
+  targetOS: fc.option(targetOSArbitrary, { nil: undefined }),
+  searchQuery: fc.option(
+    fc.string({ minLength: 1, maxLength: 20 }),
+    { nil: undefined }
+  ),
+});
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Apply filter to scripts (mimics the listScriptsBySource logic)
+ */
+function applyFilter(scripts: StoredScriptInfo[], filter: ScriptFilter): StoredScriptInfo[] {
+  return scripts.filter(script => {
+    // Filter by source
+    if (filter.source && filter.source !== 'all') {
+      if (script.source !== filter.source) {
+        return false;
+      }
+    }
+
+    // Filter by target OS (only applicable for AI-generated scripts)
+    if (filter.targetOS) {
+      if (script.source === 'ai_generated' && script.targetOS !== filter.targetOS) {
+        return false;
+      }
+    }
+
+    // Filter by search query
+    if (filter.searchQuery) {
+      const query = filter.searchQuery.toLowerCase();
+      const filename = script.filename.toLowerCase();
+      const scriptName = (script.scriptName || '').toLowerCase();
+      if (!filename.includes(query) && !scriptName.includes(query)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+/**
+ * Check if a script matches the filter criteria
+ */
+function scriptMatchesFilter(script: StoredScriptInfo, filter: ScriptFilter): boolean {
+  // Check source filter
+  if (filter.source && filter.source !== 'all') {
+    if (script.source !== filter.source) {
+      return false;
+    }
+  }
+
+  // Check target OS filter (only for AI-generated scripts)
+  if (filter.targetOS) {
+    if (script.source === 'ai_generated' && script.targetOS !== filter.targetOS) {
+      return false;
+    }
+  }
+
+  // Check search query
+  if (filter.searchQuery) {
+    const query = filter.searchQuery.toLowerCase();
+    const filename = script.filename.toLowerCase();
+    const scriptName = (script.scriptName || '').toLowerCase();
+    if (!filename.includes(query) && !scriptName.includes(query)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Verify all filtered scripts match the filter criteria
+ */
+function allScriptsMatchFilter(scripts: StoredScriptInfo[], filter: ScriptFilter): boolean {
+  return scripts.every(script => scriptMatchesFilter(script, filter));
+}
+
+/**
+ * Verify no excluded scripts are in the filtered list
+ */
+function noExcludedScripts(
+  allScripts: StoredScriptInfo[],
+  filteredScripts: StoredScriptInfo[],
+  filter: ScriptFilter
+): boolean {
+  const filteredPaths = new Set(filteredScripts.map(s => s.path));
+  
+  for (const script of allScripts) {
+    const shouldBeIncluded = scriptMatchesFilter(script, filter);
+    const isIncluded = filteredPaths.has(script.path);
+    
+    if (shouldBeIncluded !== isIncluded) {
+      return false;
+    }
+  }
+  
+  return true;
+}
+
+// ============================================================================
+// Property Tests
+// ============================================================================
+
+describe('Script Filter Correctness Property Tests', () => {
+  /**
+   * **Feature: ai-script-builder, Property 16: Script Filter Correctness**
+   * **Validates: Requirements 9.4**
+   * 
+   * For any filter selection (recorded, AI-generated, all), the filtered list
+   * SHALL contain only scripts matching the filter criteria.
+   */
+  describe('Property 16: Script Filter Correctness', () => {
+    it('filtered list contains only scripts matching filter criteria', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          scriptFilterArbitrary,
+          (scripts, filter) => {
+            const filtered = applyFilter(scripts, filter);
+            
+            // All filtered scripts must match the filter
+            return allScriptsMatchFilter(filtered, filter);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('filter by source=recorded returns only recorded scripts', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            const filter: ScriptFilter = { source: 'recorded' };
+            const filtered = applyFilter(scripts, filter);
+            
+            // All filtered scripts must be recorded
+            return filtered.every(script => script.source === 'recorded');
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('filter by source=ai_generated returns only AI-generated scripts', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            const filter: ScriptFilter = { source: 'ai_generated' };
+            const filtered = applyFilter(scripts, filter);
+            
+            // All filtered scripts must be AI-generated
+            return filtered.every(script => script.source === 'ai_generated');
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('filter by source=all returns all scripts', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            const filter: ScriptFilter = { source: 'all' };
+            const filtered = applyFilter(scripts, filter);
+            
+            // Should return all scripts
+            return filtered.length === scripts.length;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('filter by targetOS returns only matching AI scripts (recorded scripts pass through)', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          targetOSArbitrary,
+          (scripts, targetOS) => {
+            const filter: ScriptFilter = { targetOS };
+            const filtered = applyFilter(scripts, filter);
+            
+            // All filtered scripts must be either:
+            // 1. Recorded scripts (pass through)
+            // 2. AI-generated scripts with matching targetOS
+            return filtered.every(script =>
+              script.source === 'recorded' ||
+              (script.source === 'ai_generated' && script.targetOS === targetOS)
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('filter by searchQuery returns only matching scripts', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          fc.string({ minLength: 1, maxLength: 10 }),
+          (scripts, searchQuery) => {
+            const filter: ScriptFilter = { searchQuery };
+            const filtered = applyFilter(scripts, filter);
+            
+            // All filtered scripts must match the search query
+            return filtered.every(script => {
+              const query = searchQuery.toLowerCase();
+              const filename = script.filename.toLowerCase();
+              const scriptName = (script.scriptName || '').toLowerCase();
+              return filename.includes(query) || scriptName.includes(query);
+            });
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('combined filter (source + targetOS) returns correct scripts', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          targetOSArbitrary,
+          (scripts, targetOS) => {
+            const filter: ScriptFilter = {
+              source: 'ai_generated',
+              targetOS,
+            };
+            const filtered = applyFilter(scripts, filter);
+            
+            // All filtered scripts must be AI-generated with matching targetOS
+            return filtered.every(script =>
+              script.source === 'ai_generated' && script.targetOS === targetOS
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('combined filter (source + searchQuery) returns correct scripts', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          scriptSourceArbitrary,
+          fc.string({ minLength: 1, maxLength: 10 }),
+          (scripts, source, searchQuery) => {
+            const filter: ScriptFilter = {
+              source,
+              searchQuery,
+            };
+            const filtered = applyFilter(scripts, filter);
+            
+            // All filtered scripts must match both criteria
+            return filtered.every(script => {
+              const matchesSource = script.source === source;
+              const query = searchQuery.toLowerCase();
+              const filename = script.filename.toLowerCase();
+              const scriptName = (script.scriptName || '').toLowerCase();
+              const matchesQuery = filename.includes(query) || scriptName.includes(query);
+              
+              return matchesSource && matchesQuery;
+            });
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('combined filter (all three criteria) returns correct scripts', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          targetOSArbitrary,
+          fc.string({ minLength: 1, maxLength: 10 }),
+          (scripts, targetOS, searchQuery) => {
+            const filter: ScriptFilter = {
+              source: 'ai_generated',
+              targetOS,
+              searchQuery,
+            };
+            const filtered = applyFilter(scripts, filter);
+            
+            // All filtered scripts must match all three criteria
+            return filtered.every(script => {
+              const matchesSource = script.source === 'ai_generated';
+              const matchesOS = script.targetOS === targetOS;
+              const query = searchQuery.toLowerCase();
+              const filename = script.filename.toLowerCase();
+              const scriptName = (script.scriptName || '').toLowerCase();
+              const matchesQuery = filename.includes(query) || scriptName.includes(query);
+              
+              return matchesSource && matchesOS && matchesQuery;
+            });
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('no excluded scripts appear in filtered list', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          scriptFilterArbitrary,
+          (scripts, filter) => {
+            const filtered = applyFilter(scripts, filter);
+            
+            // Verify no excluded scripts are included
+            return noExcludedScripts(scripts, filtered, filter);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('empty filter returns all scripts', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            const filter: ScriptFilter = {};
+            const filtered = applyFilter(scripts, filter);
+            
+            // Should return all scripts
+            return filtered.length === scripts.length;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('filter with undefined source returns all scripts', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            const filter: ScriptFilter = { source: undefined };
+            const filtered = applyFilter(scripts, filter);
+            
+            // Should return all scripts
+            return filtered.length === scripts.length;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('targetOS filter does not exclude recorded scripts', () => {
+      fc.assert(
+        fc.property(
+          fc.array(recordedScriptArbitrary, { minLength: 1, maxLength: 10 }),
+          targetOSArbitrary,
+          (recordedScripts, targetOS) => {
+            const filter: ScriptFilter = { targetOS };
+            const filtered = applyFilter(recordedScripts, filter);
+            
+            // Recorded scripts should pass through targetOS filter
+            // (targetOS filter only applies to AI-generated scripts)
+            return filtered.length === recordedScripts.length;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('filter preserves script order', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          scriptFilterArbitrary,
+          (scripts, filter) => {
+            const filtered = applyFilter(scripts, filter);
+            
+            // Verify order is preserved by checking indices
+            let lastIndex = -1;
+            for (const filteredScript of filtered) {
+              // Find first occurrence of this script in original list
+              const index = scripts.findIndex(s => 
+                s.path === filteredScript.path && 
+                s.filename === filteredScript.filename &&
+                s.source === filteredScript.source
+              );
+              
+              if (index === -1) {
+                return false; // Script not found in original list
+              }
+              
+              if (index < lastIndex) {
+                return false; // Order not preserved
+              }
+              
+              lastIndex = index;
+            }
+            
+            return true;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('filter is case-insensitive for search query', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          fc.string({ minLength: 1, maxLength: 10 }),
+          (scripts, searchQuery) => {
+            const lowerFilter: ScriptFilter = { searchQuery: searchQuery.toLowerCase() };
+            const upperFilter: ScriptFilter = { searchQuery: searchQuery.toUpperCase() };
+            
+            const lowerFiltered = applyFilter(scripts, lowerFilter);
+            const upperFiltered = applyFilter(scripts, upperFilter);
+            
+            // Should return same results regardless of case
+            return lowerFiltered.length === upperFiltered.length;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('filter by non-existent search query returns empty list', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            // Use a search query that won't match any script
+            const filter: ScriptFilter = {
+              searchQuery: 'ZZZZZ_NONEXISTENT_QUERY_12345',
+            };
+            const filtered = applyFilter(scripts, filter);
+            
+            // Should return empty list
+            return filtered.length === 0;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('filter by macOS returns matching AI scripts and all recorded scripts', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            const filter: ScriptFilter = { targetOS: 'macos' };
+            const filtered = applyFilter(scripts, filter);
+            
+            // All filtered scripts must be either recorded or macOS AI scripts
+            return filtered.every(script =>
+              script.source === 'recorded' ||
+              (script.source === 'ai_generated' && script.targetOS === 'macos')
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('filter by Windows returns matching AI scripts and all recorded scripts', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            const filter: ScriptFilter = { targetOS: 'windows' };
+            const filtered = applyFilter(scripts, filter);
+            
+            // All filtered scripts must be either recorded or Windows AI scripts
+            return filtered.every(script =>
+              script.source === 'recorded' ||
+              (script.source === 'ai_generated' && script.targetOS === 'windows')
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('filter by Universal returns matching AI scripts and all recorded scripts', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            const filter: ScriptFilter = { targetOS: 'universal' };
+            const filtered = applyFilter(scripts, filter);
+            
+            // All filtered scripts must be either recorded or Universal AI scripts
+            return filtered.every(script =>
+              script.source === 'recorded' ||
+              (script.source === 'ai_generated' && script.targetOS === 'universal')
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('search query matches filename', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            if (scripts.length === 0) {
+              return true;
+            }
+
+            // Pick a script and search for part of its filename
+            const targetScript = scripts[0];
+            const searchQuery = targetScript.filename.substring(0, 5);
+            
+            const filter: ScriptFilter = { searchQuery };
+            const filtered = applyFilter(scripts, filter);
+            
+            // Target script should be in filtered list
+            return filtered.some(s => s.path === targetScript.path);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('search query matches script name for AI scripts', () => {
+      fc.assert(
+        fc.property(
+          fc.array(aiGeneratedScriptArbitrary, { minLength: 1, maxLength: 10 }),
+          (scripts) => {
+            // Pick a script and search for part of its script name
+            const targetScript = scripts[0];
+            const searchQuery = (targetScript.scriptName || '').substring(0, 5);
+            
+            if (!searchQuery) {
+              return true; // Skip if no script name
+            }
+            
+            const filter: ScriptFilter = { searchQuery };
+            const filtered = applyFilter(scripts, filter);
+            
+            // Target script should be in filtered list
+            return filtered.some(s => s.path === targetScript.path);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('filter returns subset of original list', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          scriptFilterArbitrary,
+          (scripts, filter) => {
+            const filtered = applyFilter(scripts, filter);
+            
+            // Filtered list should be subset of original
+            return filtered.length <= scripts.length;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('filter is idempotent', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          scriptFilterArbitrary,
+          (scripts, filter) => {
+            const filtered1 = applyFilter(scripts, filter);
+            const filtered2 = applyFilter(filtered1, filter);
+            
+            // Applying filter twice should give same result
+            return filtered1.length === filtered2.length &&
+              filtered1.every((s, i) => s.path === filtered2[i].path);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('multiple filters with same criteria return same results', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          scriptFilterArbitrary,
+          (scripts, filter) => {
+            const filtered1 = applyFilter(scripts, filter);
+            const filtered2 = applyFilter(scripts, filter);
+            
+            // Should return identical results
+            return filtered1.length === filtered2.length &&
+              filtered1.every((s, i) => s.path === filtered2[i].path);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Edge cases and boundary conditions
+   */
+  describe('Edge Cases and Boundary Conditions', () => {
+    it('handles empty script list', () => {
+      const filter: ScriptFilter = { source: 'all' };
+      const filtered = applyFilter([], filter);
+      
+      expect(filtered).toEqual([]);
+    });
+
+    it('handles filter on empty list with all criteria', () => {
+      const filter: ScriptFilter = {
+        source: 'ai_generated',
+        targetOS: 'macos',
+        searchQuery: 'test',
+      };
+      const filtered = applyFilter([], filter);
+      
+      expect(filtered).toEqual([]);
+    });
+
+    it('handles single recorded script with recorded filter', () => {
+      const script: StoredScriptInfo = {
+        filename: 'recording_test.json',
+        path: '/home/user/GeniusQA/recordings/recording_test.json',
+        createdAt: new Date().toISOString(),
+        duration: 10,
+        actionCount: 5,
+        source: 'recorded',
+      };
+
+      const filter: ScriptFilter = { source: 'recorded' };
+      const filtered = applyFilter([script], filter);
+      
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]).toEqual(script);
+    });
+
+    it('handles single AI script with AI filter', () => {
+      const script: StoredScriptInfo = {
+        filename: 'ai_script_test.json',
+        path: '/home/user/GeniusQA/recordings/ai_script_test.json',
+        createdAt: new Date().toISOString(),
+        duration: 10,
+        actionCount: 5,
+        source: 'ai_generated',
+        targetOS: 'macos',
+        scriptName: 'Test Script',
+      };
+
+      const filter: ScriptFilter = { source: 'ai_generated' };
+      const filtered = applyFilter([script], filter);
+      
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]).toEqual(script);
+    });
+
+    it('handles recorded script with AI filter', () => {
+      const script: StoredScriptInfo = {
+        filename: 'recording_test.json',
+        path: '/home/user/GeniusQA/recordings/recording_test.json',
+        createdAt: new Date().toISOString(),
+        duration: 10,
+        actionCount: 5,
+        source: 'recorded',
+      };
+
+      const filter: ScriptFilter = { source: 'ai_generated' };
+      const filtered = applyFilter([script], filter);
+      
+      expect(filtered).toHaveLength(0);
+    });
+
+    it('handles AI script with recorded filter', () => {
+      const script: StoredScriptInfo = {
+        filename: 'ai_script_test.json',
+        path: '/home/user/GeniusQA/recordings/ai_script_test.json',
+        createdAt: new Date().toISOString(),
+        duration: 10,
+        actionCount: 5,
+        source: 'ai_generated',
+        targetOS: 'macos',
+        scriptName: 'Test Script',
+      };
+
+      const filter: ScriptFilter = { source: 'recorded' };
+      const filtered = applyFilter([script], filter);
+      
+      expect(filtered).toHaveLength(0);
+    });
+
+    it('handles search query with special characters', () => {
+      const script: StoredScriptInfo = {
+        filename: 'ai_script_test-123_v2.0.json',
+        path: '/home/user/GeniusQA/recordings/ai_script_test-123_v2.0.json',
+        createdAt: new Date().toISOString(),
+        duration: 10,
+        actionCount: 5,
+        source: 'ai_generated',
+        targetOS: 'macos',
+        scriptName: 'Test Script (v2.0)',
+      };
+
+      const filter: ScriptFilter = { searchQuery: 'v2.0' };
+      const filtered = applyFilter([script], filter);
+      
+      expect(filtered).toHaveLength(1);
+    });
+
+    it('handles empty search query', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            const filter: ScriptFilter = { searchQuery: '' };
+            const filtered = applyFilter(scripts, filter);
+            
+            // Empty search query should match all scripts
+            return filtered.length === scripts.length;
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('handles whitespace-only search query', () => {
+      fc.assert(
+        fc.property(
+          scriptCombinationArbitrary,
+          (scripts) => {
+            const filter: ScriptFilter = { searchQuery: '   ' };
+            const filtered = applyFilter(scripts, filter);
+            
+            // Whitespace search query should match scripts with spaces
+            return filtered.every(script => {
+              const filename = script.filename.toLowerCase();
+              const scriptName = (script.scriptName || '').toLowerCase();
+              return filename.includes('   ') || scriptName.includes('   ');
+            });
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('handles very long search query', () => {
+      const longQuery = 'a'.repeat(1000);
+      const script: StoredScriptInfo = {
+        filename: 'recording_test.json',
+        path: '/home/user/GeniusQA/recordings/recording_test.json',
+        createdAt: new Date().toISOString(),
+        duration: 10,
+        actionCount: 5,
+        source: 'recorded',
+      };
+
+      const filter: ScriptFilter = { searchQuery: longQuery };
+      const filtered = applyFilter([script], filter);
+      
+      expect(filtered).toHaveLength(0);
+    });
+
+    it('handles scripts with missing scriptName field', () => {
+      const script: StoredScriptInfo = {
+        filename: 'ai_script_test.json',
+        path: '/home/user/GeniusQA/recordings/ai_script_test.json',
+        createdAt: new Date().toISOString(),
+        duration: 10,
+        actionCount: 5,
+        source: 'ai_generated',
+        targetOS: 'macos',
+        // scriptName is undefined
+      };
+
+      const filter: ScriptFilter = { searchQuery: 'test' };
+      const filtered = applyFilter([script], filter);
+      
+      // Should still match on filename
+      expect(filtered).toHaveLength(1);
+    });
+
+    it('handles scripts with missing targetOS field', () => {
+      const script: StoredScriptInfo = {
+        filename: 'ai_script_test.json',
+        path: '/home/user/GeniusQA/recordings/ai_script_test.json',
+        createdAt: new Date().toISOString(),
+        duration: 10,
+        actionCount: 5,
+        source: 'ai_generated',
+        scriptName: 'Test Script',
+        // targetOS is undefined
+      };
+
+      const filter: ScriptFilter = { targetOS: 'macos' };
+      const filtered = applyFilter([script], filter);
+      
+      // Should not match since targetOS doesn't match
+      expect(filtered).toHaveLength(0);
+    });
+
+    it('handles large number of scripts', () => {
+      fc.assert(
+        fc.property(
+          fc.array(scriptInfoArbitrary, { minLength: 100, maxLength: 200 }),
+          scriptFilterArbitrary,
+          (scripts, filter) => {
+            const filtered = applyFilter(scripts, filter);
+            
+            // All filtered scripts must match the filter
+            return allScriptsMatchFilter(filtered, filter);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('handles all recorded scripts', () => {
+      fc.assert(
+        fc.property(
+          fc.array(recordedScriptArbitrary, { minLength: 10, maxLength: 50 }),
+          (scripts) => {
+            const filter: ScriptFilter = { source: 'recorded' };
+            const filtered = applyFilter(scripts, filter);
+            
+            // Should return all scripts
+            return filtered.length === scripts.length;
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('handles all AI-generated scripts', () => {
+      fc.assert(
+        fc.property(
+          fc.array(aiGeneratedScriptArbitrary, { minLength: 10, maxLength: 50 }),
+          (scripts) => {
+            const filter: ScriptFilter = { source: 'ai_generated' };
+            const filtered = applyFilter(scripts, filter);
+            
+            // Should return all scripts
+            return filtered.length === scripts.length;
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('handles mixed OS types in AI scripts', () => {
+      const scripts: StoredScriptInfo[] = [
+        {
+          filename: 'ai_script_macos.json',
+          path: '/home/user/GeniusQA/recordings/ai_script_macos.json',
+          createdAt: new Date().toISOString(),
+          duration: 10,
+          actionCount: 5,
+          source: 'ai_generated',
+          targetOS: 'macos',
+          scriptName: 'macOS Script',
+        },
+        {
+          filename: 'ai_script_windows.json',
+          path: '/home/user/GeniusQA/recordings/ai_script_windows.json',
+          createdAt: new Date().toISOString(),
+          duration: 10,
+          actionCount: 5,
+          source: 'ai_generated',
+          targetOS: 'windows',
+          scriptName: 'Windows Script',
+        },
+        {
+          filename: 'ai_script_universal.json',
+          path: '/home/user/GeniusQA/recordings/ai_script_universal.json',
+          createdAt: new Date().toISOString(),
+          duration: 10,
+          actionCount: 5,
+          source: 'ai_generated',
+          targetOS: 'universal',
+          scriptName: 'Universal Script',
+        },
+      ];
+
+      const macosFilter: ScriptFilter = { targetOS: 'macos' };
+      const windowsFilter: ScriptFilter = { targetOS: 'windows' };
+      const universalFilter: ScriptFilter = { targetOS: 'universal' };
+
+      const macosFiltered = applyFilter(scripts, macosFilter);
+      const windowsFiltered = applyFilter(scripts, windowsFilter);
+      const universalFiltered = applyFilter(scripts, universalFilter);
+
+      expect(macosFiltered).toHaveLength(1);
+      expect(macosFiltered[0].targetOS).toBe('macos');
+      
+      expect(windowsFiltered).toHaveLength(1);
+      expect(windowsFiltered[0].targetOS).toBe('windows');
+      
+      expect(universalFiltered).toHaveLength(1);
+      expect(universalFiltered[0].targetOS).toBe('universal');
+    });
+  });
+});

--- a/packages/desktop/src/services/playbackService.ts
+++ b/packages/desktop/src/services/playbackService.ts
@@ -1,0 +1,419 @@
+/**
+ * Playback Service for AI Script Builder
+ * 
+ * This service provides a high-level interface for controlling script playback
+ * through the IPC bridge. It manages playback state, progress tracking, and
+ * event subscriptions for the AI Script Builder feature.
+ * 
+ * The service wraps the IPC bridge's playback commands and provides a cleaner
+ * API with progress callbacks and state management.
+ * 
+ * Requirements: 7.5
+ */
+
+import { IPCEvent, PlaybackProgress as IPCPlaybackProgress } from '../types/recorder.types';
+import { getIPCBridge } from './ipcBridgeService';
+
+/**
+ * Playback options for starting playback
+ */
+export interface PlaybackOptions {
+  speed?: number;      // Playback speed multiplier (0.1 to 10.0, default 1.0)
+  loopCount?: number;  // Number of times to loop (0 = infinite, default 1)
+}
+
+/**
+ * Playback progress information
+ */
+export interface PlaybackProgress {
+  currentAction: number;  // Current action index (0-based)
+  totalActions: number;   // Total number of actions in script
+  currentLoop: number;    // Current loop iteration (1-based)
+  totalLoops: number;     // Total loops (0 = infinite)
+  status: 'playing' | 'paused' | 'completed' | 'error';
+  error?: string;         // Error message if status is 'error'
+}
+
+/**
+ * Playback status information
+ */
+export interface PlaybackStatus {
+  isPlaying: boolean;
+  isPaused: boolean;
+  currentScript?: string;
+  progress?: PlaybackProgress;
+}
+
+/**
+ * Callback function types
+ */
+type ProgressCallback = (progress: PlaybackProgress) => void;
+type CompleteCallback = () => void;
+type ErrorCallback = (error: string) => void;
+
+/**
+ * Playback Service
+ * 
+ * Manages script playback through the IPC bridge with progress tracking
+ * and event subscriptions.
+ */
+export class PlaybackService {
+  private ipcBridge = getIPCBridge();
+  private currentScript?: string;
+  private isPlayingState = false;
+  private isPausedState = false;
+  private currentProgress?: PlaybackProgress;
+  
+  // Event callback arrays
+  private progressCallbacks: ProgressCallback[] = [];
+  private completeCallbacks: CompleteCallback[] = [];
+  private errorCallbacks: ErrorCallback[] = [];
+
+  constructor() {
+    // Set up IPC event listeners
+    this.setupEventListeners();
+  }
+
+  /**
+   * Set up IPC event listeners for playback events
+   */
+  private setupEventListeners(): void {
+    // Listen for progress events
+    this.ipcBridge.addEventListener('progress', (event: IPCEvent) => {
+      const progressData = event.data as IPCPlaybackProgress;
+      
+      this.currentProgress = {
+        currentAction: progressData.currentAction,
+        totalActions: progressData.totalActions,
+        currentLoop: progressData.currentLoop,
+        totalLoops: progressData.totalLoops,
+        status: this.isPausedState ? 'paused' : 'playing',
+      };
+      
+      // Notify all progress callbacks
+      this.progressCallbacks.forEach(callback => {
+        try {
+          callback(this.currentProgress!);
+        } catch (error) {
+          console.error('[PlaybackService] Error in progress callback:', error);
+        }
+      });
+    });
+
+    // Listen for complete events
+    this.ipcBridge.addEventListener('complete', () => {
+      this.isPlayingState = false;
+      this.isPausedState = false;
+      
+      if (this.currentProgress) {
+        this.currentProgress.status = 'completed';
+      }
+      
+      // Notify all complete callbacks
+      this.completeCallbacks.forEach(callback => {
+        try {
+          callback();
+        } catch (error) {
+          console.error('[PlaybackService] Error in complete callback:', error);
+        }
+      });
+      
+      // Reset state
+      this.currentScript = undefined;
+      this.currentProgress = undefined;
+    });
+
+    // Listen for error events
+    this.ipcBridge.addEventListener('error', (event: IPCEvent) => {
+      const errorMessage = event.data?.message || event.data?.error || 'Unknown playback error';
+      
+      this.isPlayingState = false;
+      this.isPausedState = false;
+      
+      if (this.currentProgress) {
+        this.currentProgress.status = 'error';
+        this.currentProgress.error = errorMessage;
+      }
+      
+      // Notify all error callbacks
+      this.errorCallbacks.forEach(callback => {
+        try {
+          callback(errorMessage);
+        } catch (error) {
+          console.error('[PlaybackService] Error in error callback:', error);
+        }
+      });
+      
+      // Reset state
+      this.currentScript = undefined;
+      this.currentProgress = undefined;
+    });
+
+    // Listen for playback_stopped events
+    this.ipcBridge.addEventListener('playback_stopped', () => {
+      this.isPlayingState = false;
+      this.isPausedState = false;
+      
+      if (this.currentProgress) {
+        this.currentProgress.status = 'completed';
+      }
+      
+      // Notify complete callbacks
+      this.completeCallbacks.forEach(callback => {
+        try {
+          callback();
+        } catch (error) {
+          console.error('[PlaybackService] Error in complete callback:', error);
+        }
+      });
+      
+      // Reset state
+      this.currentScript = undefined;
+      this.currentProgress = undefined;
+    });
+
+    // Listen for playback_paused events
+    this.ipcBridge.addEventListener('playback_paused', (event: IPCEvent) => {
+      const isPaused = event.data?.is_paused ?? event.data?.isPaused ?? false;
+      this.isPausedState = isPaused;
+      
+      if (this.currentProgress) {
+        this.currentProgress.status = isPaused ? 'paused' : 'playing';
+      }
+      
+      // Notify progress callbacks with updated status
+      if (this.currentProgress) {
+        this.progressCallbacks.forEach(callback => {
+          try {
+            callback(this.currentProgress!);
+          } catch (error) {
+            console.error('[PlaybackService] Error in progress callback:', error);
+          }
+        });
+      }
+    });
+  }
+
+  /**
+   * Start playback of a script
+   * 
+   * @param scriptPath - Absolute path to the script file to play
+   * @param options - Optional playback options (speed, loopCount)
+   * @throws {Error} If playback fails to start
+   * 
+   * @example
+   * await playbackService.startPlayback('/path/to/script.json', { speed: 1.5, loopCount: 2 });
+   */
+  public async startPlayback(
+    scriptPath: string,
+    options?: PlaybackOptions
+  ): Promise<void> {
+    try {
+      console.log('[PlaybackService] Starting playback:', { scriptPath, options });
+      
+      // Start playback through IPC bridge
+      await this.ipcBridge.startPlayback(
+        scriptPath,
+        options?.speed,
+        options?.loopCount
+      );
+      
+      // Update state
+      this.currentScript = scriptPath;
+      this.isPlayingState = true;
+      this.isPausedState = false;
+      this.currentProgress = {
+        currentAction: 0,
+        totalActions: 0,
+        currentLoop: 1,
+        totalLoops: options?.loopCount || 1,
+        status: 'playing',
+      };
+      
+      console.log('[PlaybackService] Playback started successfully');
+    } catch (error) {
+      console.error('[PlaybackService] Failed to start playback:', error);
+      this.isPlayingState = false;
+      this.isPausedState = false;
+      this.currentScript = undefined;
+      this.currentProgress = undefined;
+      throw error;
+    }
+  }
+
+  /**
+   * Stop current playback
+   * 
+   * @throws {Error} If no playback is active or stop fails
+   * 
+   * @example
+   * await playbackService.stopPlayback();
+   */
+  public async stopPlayback(): Promise<void> {
+    try {
+      console.log('[PlaybackService] Stopping playback');
+      
+      await this.ipcBridge.stopPlayback();
+      
+      // State will be reset by the playback_stopped event listener
+      console.log('[PlaybackService] Playback stopped successfully');
+    } catch (error) {
+      console.error('[PlaybackService] Failed to stop playback:', error);
+      // Reset state even on error
+      this.isPlayingState = false;
+      this.isPausedState = false;
+      this.currentScript = undefined;
+      this.currentProgress = undefined;
+      throw error;
+    }
+  }
+
+  /**
+   * Toggle pause/resume playback
+   * 
+   * @returns {Promise<boolean>} True if playback is now paused, false if resumed
+   * @throws {Error} If no playback is active or pause fails
+   * 
+   * @example
+   * const isPaused = await playbackService.togglePause();
+   * console.log(isPaused ? 'Paused' : 'Resumed');
+   */
+  public async togglePause(): Promise<boolean> {
+    try {
+      console.log('[PlaybackService] Toggling pause');
+      
+      const isPaused = await this.ipcBridge.pausePlayback();
+      
+      // Update state
+      this.isPausedState = isPaused;
+      
+      if (this.currentProgress) {
+        this.currentProgress.status = isPaused ? 'paused' : 'playing';
+      }
+      
+      console.log('[PlaybackService] Pause toggled:', isPaused);
+      return isPaused;
+    } catch (error) {
+      console.error('[PlaybackService] Failed to toggle pause:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get current playback status
+   * 
+   * @returns {PlaybackStatus} Current playback status
+   * 
+   * @example
+   * const status = playbackService.getStatus();
+   * if (status.isPlaying) {
+   *   console.log('Playing:', status.currentScript);
+   * }
+   */
+  public getStatus(): PlaybackStatus {
+    return {
+      isPlaying: this.isPlayingState,
+      isPaused: this.isPausedState,
+      currentScript: this.currentScript,
+      progress: this.currentProgress,
+    };
+  }
+
+  /**
+   * Subscribe to playback progress events
+   * 
+   * @param callback - Function to call on progress updates
+   * @returns Unsubscribe function
+   * 
+   * @example
+   * const unsubscribe = playbackService.onProgress((progress) => {
+   *   console.log(`Action ${progress.currentAction}/${progress.totalActions}`);
+   * });
+   * // Later: unsubscribe();
+   */
+  public onProgress(callback: ProgressCallback): () => void {
+    this.progressCallbacks.push(callback);
+    
+    // Return unsubscribe function
+    return () => {
+      const index = this.progressCallbacks.indexOf(callback);
+      if (index !== -1) {
+        this.progressCallbacks.splice(index, 1);
+      }
+    };
+  }
+
+  /**
+   * Subscribe to playback complete events
+   * 
+   * @param callback - Function to call when playback completes
+   * @returns Unsubscribe function
+   * 
+   * @example
+   * const unsubscribe = playbackService.onComplete(() => {
+   *   console.log('Playback completed!');
+   * });
+   * // Later: unsubscribe();
+   */
+  public onComplete(callback: CompleteCallback): () => void {
+    this.completeCallbacks.push(callback);
+    
+    // Return unsubscribe function
+    return () => {
+      const index = this.completeCallbacks.indexOf(callback);
+      if (index !== -1) {
+        this.completeCallbacks.splice(index, 1);
+      }
+    };
+  }
+
+  /**
+   * Subscribe to playback error events
+   * 
+   * @param callback - Function to call when an error occurs
+   * @returns Unsubscribe function
+   * 
+   * @example
+   * const unsubscribe = playbackService.onError((error) => {
+   *   console.error('Playback error:', error);
+   * });
+   * // Later: unsubscribe();
+   */
+  public onError(callback: ErrorCallback): () => void {
+    this.errorCallbacks.push(callback);
+    
+    // Return unsubscribe function
+    return () => {
+      const index = this.errorCallbacks.indexOf(callback);
+      if (index !== -1) {
+        this.errorCallbacks.splice(index, 1);
+      }
+    };
+  }
+}
+
+// Export singleton instance
+let playbackServiceInstance: PlaybackService | null = null;
+
+/**
+ * Get the singleton PlaybackService instance
+ * 
+ * @returns {PlaybackService} The playback service instance
+ * 
+ * @example
+ * const playbackService = getPlaybackService();
+ * await playbackService.startPlayback('/path/to/script.json');
+ */
+export function getPlaybackService(): PlaybackService {
+  if (!playbackServiceInstance) {
+    playbackServiceInstance = new PlaybackService();
+  }
+  return playbackServiceInstance;
+}
+
+/**
+ * Reset the PlaybackService singleton (mainly for testing)
+ */
+export function resetPlaybackService(): void {
+  playbackServiceInstance = null;
+}

--- a/packages/desktop/src/services/scriptStorageService.ts
+++ b/packages/desktop/src/services/scriptStorageService.ts
@@ -7,31 +7,30 @@
  * Requirements: 4.3, 5.5, 5.6, 6.5, 9.1, 9.4
  */
 
-import { getIPCBridge } from './ipcBridgeService';
-import { ScriptData, Action } from '../types/aiScriptBuilder.types';
-import { 
-  AIVisionCaptureAction, 
-  InteractionType, 
-  SearchScope,
+import { Action, ScriptData } from '../types/aiScriptBuilder.types';
+import {
+    AIVisionCaptureAction,
+    InteractionType,
+    SearchScope,
 } from '../types/aiVisionCapture.types';
-import { toPosixPath } from './assetManager';
-import { 
-  TestScript, 
-  TestStep, 
-  ActionWithId, 
-  EnhancedScriptMetadata,
-  MigrationResult 
+import {
+    ActionWithId,
+    MigrationResult,
+    TestScript,
+    TestStep
 } from '../types/testCaseDriven.types';
-import { TestScriptMigrationService } from './testScriptMigrationService';
-import { 
-  validateTestScript as validateTestScriptStructure, 
-  repairTestScript, 
-  createFallbackScript,
-  formatStepErrors,
-  canSafelyLoadScript,
-  StepValidationResult,
-  RecoveryResult,
+import {
+    canSafelyLoadScript,
+    createFallbackScript,
+    formatStepErrors,
+    RecoveryResult,
+    repairTestScript,
+    StepValidationResult,
+    validateTestScript as validateTestScriptStructure,
 } from '../utils/stepErrorHandling';
+import { toPosixPath } from './assetManager';
+import { getIPCBridge } from './ipcBridgeService';
+import { TestScriptMigrationService } from './testScriptMigrationService';
 
 /**
  * Extended action type that includes AI Vision Capture actions
@@ -126,9 +125,16 @@ export function generateScriptPath(scriptName: string): string {
  * Ensures all required fields are present and properly formatted
  * @param script - The script data to prepare
  * @param scriptName - The name for the script
+ * @param targetOS - The target operating system for the script (optional)
  * @returns Prepared script data
+ * 
+ * Requirements: 7.3, 8.6
  */
-export function prepareScriptForSave(script: ScriptData, scriptName: string): ScriptData {
+export function prepareScriptForSave(
+  script: ScriptData, 
+  scriptName: string,
+  targetOS?: TargetOS
+): ScriptData {
   const now = new Date().toISOString();
   
   return {
@@ -143,8 +149,10 @@ export function prepareScriptForSave(script: ScriptData, scriptName: string): Sc
       additional_data: {
         ...script.metadata.additional_data,
         script_name: scriptName,
+        source: 'ai_generated',
         generated_by: 'ai_script_builder',
         generated_at: now,
+        ...(targetOS && { target_os: targetOS }),
       },
     },
   };
@@ -249,14 +257,19 @@ class ScriptStorageService {
    * 
    * @param script - The script data to save
    * @param scriptName - The name for the script
+   * @param targetOS - The target operating system for the script (optional)
    * @returns Result of the save operation
    * 
-   * Requirements: 5.5
+   * Requirements: 5.5, 7.3, 8.6
    */
-  async saveScript(script: ScriptData, scriptName: string): Promise<ScriptSaveResult> {
+  async saveScript(
+    script: ScriptData, 
+    scriptName: string,
+    targetOS?: TargetOS
+  ): Promise<ScriptSaveResult> {
     try {
-      // Prepare the script data
-      const preparedScript = prepareScriptForSave(script, scriptName);
+      // Prepare the script data with AI metadata
+      const preparedScript = prepareScriptForSave(script, scriptName, targetOS);
       
       // Generate the filename
       const filename = generateScriptPath(scriptName);
@@ -279,6 +292,8 @@ class ScriptStorageService {
         scriptPath,
         actionCount: processedScript.actions.length,
         hasVisionActions,
+        source: 'ai_generated',
+        targetOS: targetOS || 'not specified',
       });
 
       // Ensure assets folder exists if there are vision actions
@@ -1675,5 +1690,6 @@ export default scriptStorageService;
 
 // Export additional utility functions for external use
 export {
-  TestScriptMigrationService,
+    TestScriptMigrationService
 };
+

--- a/packages/python-core/examples/self_running_macos_demo.py
+++ b/packages/python-core/examples/self_running_macos_demo.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+Self-running macOS automation demo — end-to-end loop.
+
+Exercises the full GeniusQA automation pipeline with REAL components:
+
+    1. Capture a screenshot (real screen, or a synthetic rendered UI in SAFE mode)
+    2. Scan text / OCR locally (Tesseract, 0 token) to locate a target label
+    3. Write an automation script targeting the located coordinates
+    4. Execute the script (dry-run by default; real pyautogui only with --live)
+    5. Demonstrate the LLM-coordinate-analysis fallback path (mocked unless a
+       GEMINI_API_KEY is provided)
+    6. Print token accounting (local_ocr_hits vs llm_calls)
+
+By default this is SAFE and self-contained: it renders a synthetic screenshot
+with a known "Submit" label so the loop is deterministic and never moves the
+real cursor. Pass --real-screen to OCR the actual screen, and --live to actually
+drive pyautogui (use with care).
+
+Usage:
+    python3 examples/self_running_macos_demo.py
+    python3 examples/self_running_macos_demo.py --real-screen
+    python3 examples/self_running_macos_demo.py --live          # moves the mouse!
+
+Exit code 0 means the loop completed and the target was located.
+"""
+
+import argparse
+import asyncio
+import base64
+import io
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Make `src` importable when run from the package root.
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from PIL import Image, ImageDraw  # noqa: E402
+
+from src.vision.local_ocr_service import LocalOCRService  # noqa: E402
+from src.vision.ai_vision_service import (  # noqa: E402
+    AIVisionService,
+    AIVisionRequest,
+    AIVisionResponse,
+)
+
+
+TARGET_LABEL = "Submit"
+
+
+def log(step: str, msg: str) -> None:
+    print(f"[{step}] {msg}")
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — Screenshot capture
+# ---------------------------------------------------------------------------
+
+def render_synthetic_screenshot() -> str:
+    """Render a deterministic UI containing a 'Submit' button; return base64 PNG."""
+    img = Image.new("RGB", (640, 360), "white")
+    d = ImageDraw.Draw(img)
+    d.rectangle([40, 40, 200, 90], outline="black", width=2)
+    d.text((70, 58), "Cancel", fill="black")
+    d.rectangle([260, 200, 420, 250], outline="black", width=2)
+    d.text((300, 218), TARGET_LABEL, fill="black")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+class ScreenCaptureError(Exception):
+    """Raised when the real screen cannot be captured (e.g. missing permission)."""
+
+
+def capture_real_screenshot() -> str:
+    """
+    Capture the real screen via pyautogui; return base64 PNG.
+
+    On macOS this requires the Screen Recording permission for the running
+    process. If capture fails (permission missing, headless, etc.) we raise
+    ScreenCaptureError so the caller can degrade gracefully rather than crash.
+    """
+    try:
+        import pyautogui  # imported lazily so SAFE mode needs no screen access
+        shot = pyautogui.screenshot()
+        if shot is None:
+            raise ScreenCaptureError("screenshot() returned None")
+        buf = io.BytesIO()
+        shot.save(buf, format="PNG")
+        return base64.b64encode(buf.getvalue()).decode()
+    except ScreenCaptureError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - surface a clear, actionable error
+        raise ScreenCaptureError(str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — Write an automation script
+# ---------------------------------------------------------------------------
+
+def build_script(x: int, y: int, target: str) -> dict:
+    """Build a minimal click-at-coordinate automation script (GeniusQA format)."""
+    return {
+        "version": "1.0",
+        "metadata": {
+            "duration": 0,
+            "action_count": 2,
+            "core_type": "python",
+            "platform": "macos",
+            "additional_data": {
+                "source": "self_running_demo",
+                "target_label": target,
+            },
+        },
+        "actions": [
+            {"type": "mouse_move", "timestamp": 0, "x": x, "y": y},
+            {"type": "mouse_click", "timestamp": 100, "x": x, "y": y, "button": "left"},
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Step 4 — Execute the script
+# ---------------------------------------------------------------------------
+
+def execute_script(script: dict, live: bool) -> None:
+    """Execute actions. Dry-run logs each action; --live drives pyautogui."""
+    for i, action in enumerate(script["actions"]):
+        atype = action["type"]
+        if live:
+            import pyautogui
+            if atype == "mouse_move":
+                pyautogui.moveTo(action["x"], action["y"], _pause=False)
+            elif atype == "mouse_click":
+                pyautogui.click(action["x"], action["y"],
+                                button=action.get("button", "left"), _pause=False)
+            log("EXEC", f"action {i}: {atype} -> LIVE at ({action.get('x')},{action.get('y')})")
+        else:
+            log("EXEC", f"action {i}: {atype} -> DRY-RUN at ({action.get('x')},{action.get('y')})")
+
+
+# ---------------------------------------------------------------------------
+# Step 5 — LLM-coordinate-analysis fallback demonstration
+# ---------------------------------------------------------------------------
+
+async def demo_llm_fallback(screenshot_b64: str) -> AIVisionResponse:
+    """
+    Show the LLM fallback path for a NON-text / visual prompt where local OCR
+    cannot help. If GEMINI_API_KEY is set we make a real call; otherwise we
+    inject a mock LLM so the loop is fully self-contained.
+    """
+    api_key = os.environ.get("GEMINI_API_KEY")
+    svc = AIVisionService()
+    await svc.initialize(api_key or "demo-key")
+
+    if not api_key:
+        async def mock_llm(*args, **kwargs):
+            return AIVisionResponse(success=True, x=330, y=225, confidence=0.83)
+        svc._call_gemini_vision_api = mock_llm  # type: ignore[assignment]
+
+    # A visual prompt with no quoted text target -> OCR is skipped -> LLM runs.
+    req = AIVisionRequest(screenshot=screenshot_b64,
+                          prompt="the highlighted primary action button")
+    resp = await svc.analyze(req)
+    log("LLM", f"fallback analyze -> success={resp.success} "
+                f"coords=({resp.x},{resp.y}) conf={resp.confidence} "
+                f"(local_ocr_hits={svc.local_ocr_hits}, llm_calls={svc.llm_calls})")
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description="Self-running macOS automation demo")
+    parser.add_argument("--real-screen", action="store_true",
+                        help="OCR the actual screen instead of a synthetic image")
+    parser.add_argument("--live", action="store_true",
+                        help="Actually drive pyautogui (moves the real mouse!)")
+    args = parser.parse_args()
+
+    ocr = LocalOCRService()
+    log("ENV", f"local OCR available: {ocr.is_available()}")
+
+    # Step 1: screenshot
+    if args.real_screen:
+        try:
+            screenshot = capture_real_screenshot()
+            log("CAPTURE", "captured real screen")
+        except ScreenCaptureError as exc:
+            log("CAPTURE", f"real screen capture failed ({exc}).")
+            log("PERMISSION", "Grant Screen Recording permission to this process: "
+                             "System Settings > Privacy & Security > Screen Recording. "
+                             "Falling back to synthetic UI so the loop still completes.")
+            screenshot = render_synthetic_screenshot()
+    else:
+        screenshot = render_synthetic_screenshot()
+        log("CAPTURE", "rendered synthetic UI with a 'Submit' button")
+
+    # Step 2: scan text / OCR (0 token)
+    if not ocr.is_available():
+        log("OCR", "Tesseract unavailable — would defer to LLM for all targets")
+        # Still demonstrate the LLM fallback so the loop completes.
+        await demo_llm_fallback(screenshot)
+        log("DONE", "completed via LLM-only path (no local OCR engine)")
+        return 0
+
+    boxes = ocr.extract_text_boxes(screenshot)
+    log("OCR", f"scanned {len(boxes)} text box(es): "
+               f"{[b.text for b in boxes][:10]}")
+
+    result = ocr.locate_text(screenshot, TARGET_LABEL)
+    if not result.success:
+        log("OCR", f"could not locate '{TARGET_LABEL}' locally; falling back to LLM")
+        resp = await demo_llm_fallback(screenshot)
+        if not resp.success:
+            log("DONE", "FAILED: target not found by OCR or LLM")
+            return 1
+        x, y = resp.x, resp.y
+    else:
+        x, y = result.x, result.y
+        log("OCR", f"located '{TARGET_LABEL}' at ({x},{y}) "
+                   f"conf={result.confidence} — 0 TOKEN COST")
+
+    # Step 3: write script
+    script = build_script(x, y, TARGET_LABEL)
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(script, f, indent=2)
+        script_path = f.name
+    log("SCRIPT", f"wrote automation script -> {script_path}")
+
+    # Step 4: execute
+    execute_script(script, live=args.live)
+
+    # Step 5: LLM fallback demonstration (separate visual target)
+    await demo_llm_fallback(screenshot)
+
+    log("DONE", "self-running automation loop completed successfully")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/packages/python-core/requirements.txt
+++ b/packages/python-core/requirements.txt
@@ -10,3 +10,8 @@ pydantic==2.5.0
 aiohttp==3.9.0
 Pillow==10.1.0
 jinja2==3.1.2
+
+# Optional: local OCR fallback (token-saving text targeting). The service
+# degrades gracefully if this or the tesseract binary is absent.
+# Requires the system `tesseract` binary (macOS: `brew install tesseract`).
+pytesseract==0.3.13

--- a/packages/python-core/src/test_self_running_macos_e2e.py
+++ b/packages/python-core/src/test_self_running_macos_e2e.py
@@ -1,0 +1,119 @@
+"""
+Self-running end-to-end test for the macOS automation loop.
+
+Runs the full pipeline (screenshot -> OCR/scan text -> build script -> execute
+dry-run -> LLM-coordinate fallback -> token accounting) using REAL components in
+SAFE mode (synthetic screenshot, no cursor movement, mocked LLM). This is the
+automated counterpart of examples/self_running_macos_demo.py and guards the loop
+against regressions.
+
+Requirements: local-ocr-token-optimization 5.1, 5.2.
+"""
+
+import asyncio
+import base64
+import io
+import sys
+from pathlib import Path
+
+import pytest
+from PIL import Image, ImageDraw
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.vision.local_ocr_service import LocalOCRService
+from src.vision.ai_vision_service import (
+    AIVisionService,
+    AIVisionRequest,
+    AIVisionResponse,
+)
+
+TARGET = "Submit"
+
+
+def _synthetic_screenshot() -> str:
+    img = Image.new("RGB", (640, 360), "white")
+    d = ImageDraw.Draw(img)
+    d.rectangle([260, 200, 420, 250], outline="black", width=2)
+    d.text((300, 218), TARGET, fill="black")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+@pytest.mark.skipif(
+    not LocalOCRService().is_available(),
+    reason="Tesseract OCR engine not available on this host",
+)
+def test_full_loop_locates_text_with_zero_tokens():
+    """Screenshot -> OCR -> script -> execute(dry) completes with 0 LLM calls."""
+    shot = _synthetic_screenshot()
+    ocr = LocalOCRService()
+
+    boxes = ocr.extract_text_boxes(shot)
+    assert any("submit" in b.text.lower() for b in boxes), \
+        f"OCR should detect the Submit label, got {[b.text for b in boxes]}"
+
+    result = ocr.locate_text(shot, TARGET)
+    assert result.success, "Local OCR should locate the Submit label"
+    assert result.x is not None and result.y is not None
+
+    # Build + 'execute' (dry-run) a script targeting the located coordinates.
+    script = {
+        "version": "1.0",
+        "metadata": {"action_count": 2, "core_type": "python", "platform": "macos"},
+        "actions": [
+            {"type": "mouse_move", "x": result.x, "y": result.y},
+            {"type": "mouse_click", "x": result.x, "y": result.y, "button": "left"},
+        ],
+    }
+    executed = [a["type"] for a in script["actions"]]  # dry-run: no pyautogui
+    assert executed == ["mouse_move", "mouse_click"]
+
+
+def test_llm_fallback_path_is_self_contained():
+    """A visual (non-text) prompt skips OCR and uses the (mocked) LLM path."""
+    shot = _synthetic_screenshot()
+    svc = AIVisionService()
+    _run(svc.initialize("demo-key"))
+
+    async def mock_llm(*args, **kwargs):
+        return AIVisionResponse(success=True, x=330, y=225, confidence=0.83)
+
+    svc._call_gemini_vision_api = mock_llm  # type: ignore[assignment]
+
+    req = AIVisionRequest(screenshot=shot, prompt="the highlighted primary button")
+    resp = _run(svc.analyze(req))
+    assert resp.success
+    assert (resp.x, resp.y) == (330, 225)
+    assert svc.local_ocr_hits == 0
+    assert svc.llm_calls == 1
+
+
+@pytest.mark.skipif(
+    not LocalOCRService().is_available(),
+    reason="Tesseract OCR engine not available on this host",
+)
+def test_text_target_avoids_llm_entirely():
+    """End-to-end: quoted text target is served by OCR, LLM never called."""
+    shot = _synthetic_screenshot()
+    svc = AIVisionService()  # real LocalOCRService inside
+    _run(svc.initialize("demo-key"))
+
+    # Guard: if the LLM is invoked, fail loudly.
+    async def forbidden_llm(*args, **kwargs):
+        raise AssertionError("LLM must not be called for an OCR-locatable target")
+
+    svc._call_gemini_vision_api = forbidden_llm  # type: ignore[assignment]
+
+    req = AIVisionRequest(screenshot=shot, prompt='Click the "Submit" button')
+    resp = _run(svc.analyze(req))
+    assert resp.success
+    assert svc.local_ocr_hits == 1
+    assert svc.llm_calls == 0

--- a/packages/python-core/src/vision/__init__.py
+++ b/packages/python-core/src/vision/__init__.py
@@ -19,6 +19,13 @@ from .image_utils import (
     encode_image_base64,
     decode_image_base64,
 )
+from .local_ocr_service import (
+    LocalOCRService,
+    LocalOCRResult,
+    OCRMatch,
+    normalize_text,
+    text_match_score,
+)
 
 __all__ = [
     'AIVisionService',
@@ -29,4 +36,9 @@ __all__ = [
     'scale_roi',
     'encode_image_base64',
     'decode_image_base64',
+    'LocalOCRService',
+    'LocalOCRResult',
+    'OCRMatch',
+    'normalize_text',
+    'text_match_score',
 ]

--- a/packages/python-core/src/vision/ai_vision_service.py
+++ b/packages/python-core/src/vision/ai_vision_service.py
@@ -15,6 +15,7 @@ from typing import Optional, List
 import aiohttp
 
 from .image_utils import crop_to_roi, encode_image_base64
+from .local_ocr_service import LocalOCRService
 
 
 # ============================================================================
@@ -215,11 +216,29 @@ class AIVisionService:
         ...     print(f"Found at ({response.x}, {response.y})")
     """
     
-    def __init__(self):
-        """Initialize the AI Vision Service."""
+    def __init__(self, local_ocr: Optional[LocalOCRService] = None,
+                 enable_local_ocr: bool = True):
+        """
+        Initialize the AI Vision Service.
+
+        Args:
+            local_ocr: Optional LocalOCRService instance (injectable for tests).
+            enable_local_ocr: When True (default), attempt a zero-token local OCR
+                lookup before falling back to the cloud Vision LLM. This is the
+                primary token-saving path for plain-text targets.
+        """
         self._api_key: Optional[str] = None
         self._initialized: bool = False
         self._timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS
+        self._enable_local_ocr: bool = enable_local_ocr
+        self._local_ocr: LocalOCRService = local_ocr or LocalOCRService()
+        # Lightweight telemetry so callers can quantify token savings.
+        self.local_ocr_hits: int = 0
+        self.llm_calls: int = 0
+
+    def set_local_ocr_enabled(self, enabled: bool) -> None:
+        """Enable or disable the local-OCR token-saving fast path."""
+        self._enable_local_ocr = enabled
     
     async def initialize(self, api_key: str) -> None:
         """
@@ -321,6 +340,22 @@ class AIVisionService:
                     # Continue with full image if cropping fails
                     print(f"Warning: Failed to crop image to ROI: {crop_error}")
             
+            # ----------------------------------------------------------------
+            # Token-saving fast path: try LOCAL OCR before the cloud LLM.
+            #
+            # If the prompt names a concrete text target (e.g. a quoted label)
+            # and a local Tesseract pass locates it confidently, we return that
+            # result at ZERO token cost and skip the LLM entirely. Reference
+            # images imply visual (non-text) matching, so we skip OCR for those.
+            # ----------------------------------------------------------------
+            if self._enable_local_ocr and not request.reference_images:
+                local_response = self._try_local_ocr(
+                    screenshot_base64, request.prompt, roi_offset_x, roi_offset_y
+                )
+                if local_response is not None:
+                    self.local_ocr_hits += 1
+                    return local_response
+
             # Prepare reference images
             reference_images_base64: List[str] = []
             for ref_image in request.reference_images:
@@ -329,8 +364,9 @@ class AIVisionService:
                     reference_images_base64.append(base64_data)
                 except Exception:
                     print("Warning: Failed to process reference image, skipping")
-            
+
             # Make API request with timeout
+            self.llm_calls += 1
             response = await self._call_gemini_vision_api(
                 screenshot_base64,
                 request.prompt,
@@ -365,6 +401,43 @@ class AIVisionService:
                 error=f"AI analysis failed: {error_message}"
             )
     
+    def _try_local_ocr(
+        self,
+        screenshot_base64: str,
+        prompt: str,
+        roi_offset_x: int,
+        roi_offset_y: int,
+    ) -> Optional[AIVisionResponse]:
+        """
+        Attempt a zero-token local OCR lookup for a text target in the prompt.
+
+        Returns:
+            AIVisionResponse on a confident local hit (ROI offset already
+            applied), or None to signal "fall back to the cloud LLM".
+        """
+        if not self._local_ocr.is_available():
+            return None
+
+        query = LocalOCRService.extract_query_from_prompt(prompt)
+        if not query:
+            return None
+
+        try:
+            result = self._local_ocr.locate_text(screenshot_base64, query)
+        except Exception:
+            # Any OCR failure must never break analysis — defer to the LLM.
+            return None
+
+        if not result.success or result.x is None or result.y is None:
+            return None
+
+        return AIVisionResponse(
+            success=True,
+            x=result.x + roi_offset_x,
+            y=result.y + roi_offset_y,
+            confidence=result.confidence,
+        )
+
     async def _call_gemini_vision_api(
         self,
         screenshot_base64: str,

--- a/packages/python-core/src/vision/local_ocr_service.py
+++ b/packages/python-core/src/vision/local_ocr_service.py
@@ -1,0 +1,294 @@
+"""
+Local OCR Service for AI Vision Capture (token-saving fallback).
+
+This service locates on-screen text elements using a LOCAL OCR engine
+(Tesseract via pytesseract) instead of calling a paid cloud Vision LLM.
+
+Why this exists
+---------------
+The cloud Vision LLM (Gemini) is accurate but every analysis costs tokens and
+requires network access. A large fraction of real automation targets are plain
+text labels ("Submit", "Login", "Đăng nhập", ...). For those, a local OCR pass
+can find the element with ZERO token cost and no network dependency.
+
+Strategy: the AIVisionService tries this local OCR path FIRST. Only when local
+OCR cannot confidently locate the requested text does it fall back to the cloud
+LLM. This is the primary token-optimization mechanism for text targets.
+
+Design notes
+------------
+- pytesseract / the tesseract binary are OPTIONAL. If either is unavailable the
+  service degrades gracefully (is_available() -> False) and the caller simply
+  uses the LLM path. Nothing here is a hard dependency.
+- The matcher is intentionally conservative: it only reports `found=True` when a
+  reasonably strong textual match exists, so we never silently click the wrong
+  element. Ambiguous cases defer to the LLM.
+
+Requirements: token optimization for ai-vision-capture (local text fallback).
+"""
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+from .image_utils import decode_image_base64, encode_image_base64
+
+
+# ============================================================================
+# Optional dependency probing (no hard import failure)
+# ============================================================================
+
+def _probe_pytesseract():
+    """Return the pytesseract module if importable, else None."""
+    try:
+        import pytesseract  # type: ignore
+        return pytesseract
+    except Exception:
+        return None
+
+
+_pytesseract = _probe_pytesseract()
+
+
+# ============================================================================
+# Data classes
+# ============================================================================
+
+@dataclass
+class OCRMatch:
+    """A single OCR text box with its center coordinates and confidence."""
+    text: str
+    x: int          # center x (pixels)
+    y: int          # center y (pixels)
+    confidence: float  # 0.0 - 1.0
+    left: int
+    top: int
+    width: int
+    height: int
+
+
+@dataclass
+class LocalOCRResult:
+    """Result of a local OCR locate attempt."""
+    success: bool
+    x: Optional[int] = None
+    y: Optional[int] = None
+    confidence: Optional[float] = None
+    matched_text: Optional[str] = None
+    error: Optional[str] = None
+
+
+# ============================================================================
+# Text normalization / matching helpers
+# ============================================================================
+
+def normalize_text(text: str) -> str:
+    """
+    Normalize text for tolerant comparison.
+
+    Lowercases, collapses whitespace, and strips surrounding punctuation so that
+    "Submit", " submit ", and "Submit:" all compare equal.
+    """
+    if not text:
+        return ""
+    collapsed = re.sub(r"\s+", " ", text).strip().lower()
+    # Strip leading/trailing punctuation but keep internal characters intact.
+    return collapsed.strip(" \t\n\r.,:;!?\"'()[]{}<>|")
+
+
+def text_match_score(query: str, candidate: str) -> float:
+    """
+    Score how well `candidate` text matches the `query`, in [0.0, 1.0].
+
+    Tiers (most → least confident):
+      1.0  exact normalized equality
+      0.9  candidate equals query as a whole word inside it
+      0.75 query is a contained substring (or vice-versa) of meaningful length
+      0.0  otherwise
+
+    Kept deliberately simple and conservative — fuzzy edit-distance matching is
+    intentionally avoided so we don't click the wrong control on a near-miss.
+    """
+    q = normalize_text(query)
+    c = normalize_text(candidate)
+    if not q or not c:
+        return 0.0
+    if q == c:
+        return 1.0
+    # whole-word containment
+    if re.search(rf"(?:^|\s){re.escape(q)}(?:$|\s)", c):
+        return 0.9
+    # substring containment, but only when the query is non-trivial
+    if len(q) >= 3 and (q in c or c in q):
+        return 0.75
+    return 0.0
+
+
+# ============================================================================
+# Service
+# ============================================================================
+
+class LocalOCRService:
+    """
+    Locate on-screen text using local Tesseract OCR (zero token cost).
+
+    Example:
+        >>> svc = LocalOCRService()
+        >>> if svc.is_available():
+        ...     result = svc.locate_text(screenshot_base64, "Submit")
+        ...     if result.success:
+        ...         click(result.x, result.y)
+    """
+
+    # Minimum combined confidence (OCR confidence * match score) required to
+    # accept a local hit. Below this we defer to the cloud LLM.
+    DEFAULT_MIN_CONFIDENCE = 0.5
+
+    def __init__(self, min_confidence: float = DEFAULT_MIN_CONFIDENCE):
+        self._min_confidence = min_confidence
+
+    def is_available(self) -> bool:
+        """
+        True only if pytesseract is importable AND the tesseract binary works.
+
+        This double-check means the caller never has to handle a missing binary
+        at locate time — an unavailable engine simply means "use the LLM".
+        """
+        if _pytesseract is None:
+            return False
+        try:
+            _pytesseract.get_tesseract_version()
+            return True
+        except Exception:
+            return False
+
+    def extract_text_boxes(self, screenshot: str, lang: Optional[str] = None) -> List[OCRMatch]:
+        """
+        Run OCR over the screenshot and return all detected text boxes.
+
+        Args:
+            screenshot: base64 string, data URL, or file path.
+            lang: optional Tesseract language string (e.g. "eng+vie").
+
+        Returns:
+            List of OCRMatch. Empty list if OCR is unavailable or finds nothing.
+        """
+        if not self.is_available():
+            return []
+
+        try:
+            image = decode_image_base64(encode_image_base64(screenshot))
+        except Exception:
+            return []
+
+        # Tesseract reads RGB; convert to be safe across PNG/RGBA inputs.
+        if image.mode not in ("RGB", "L"):
+            image = image.convert("RGB")
+
+        try:
+            config_kwargs = {"output_type": _pytesseract.Output.DICT}
+            if lang:
+                config_kwargs["lang"] = lang
+            data = _pytesseract.image_to_data(image, **config_kwargs)
+        except Exception:
+            return []
+
+        matches: List[OCRMatch] = []
+        n = len(data.get("text", []))
+        for i in range(n):
+            raw_text = (data["text"][i] or "").strip()
+            if not raw_text:
+                continue
+            try:
+                conf_raw = float(data["conf"][i])
+            except (ValueError, TypeError):
+                continue
+            # Tesseract returns -1 for non-text regions.
+            if conf_raw < 0:
+                continue
+            left = int(data["left"][i])
+            top = int(data["top"][i])
+            width = int(data["width"][i])
+            height = int(data["height"][i])
+            matches.append(
+                OCRMatch(
+                    text=raw_text,
+                    x=left + width // 2,
+                    y=top + height // 2,
+                    confidence=max(0.0, min(1.0, conf_raw / 100.0)),
+                    left=left,
+                    top=top,
+                    width=width,
+                    height=height,
+                )
+            )
+        return matches
+
+    def locate_text(
+        self,
+        screenshot: str,
+        query: str,
+        lang: Optional[str] = None,
+    ) -> LocalOCRResult:
+        """
+        Find the best on-screen match for `query` text.
+
+        Returns a successful LocalOCRResult only when the combined confidence
+        (OCR confidence * textual match score) meets the configured threshold;
+        otherwise success=False so the caller can fall back to the cloud LLM.
+
+        This call costs ZERO tokens and requires no network access.
+        """
+        if not self.is_available():
+            return LocalOCRResult(success=False, error="Local OCR engine not available")
+        if not query or not query.strip():
+            return LocalOCRResult(success=False, error="Query text is required")
+
+        boxes = self.extract_text_boxes(screenshot, lang=lang)
+        if not boxes:
+            return LocalOCRResult(success=False, error="No text detected on screen")
+
+        best: Optional[OCRMatch] = None
+        best_combined = 0.0
+        best_match_score = 0.0
+        for box in boxes:
+            match_score = text_match_score(query, box.text)
+            if match_score <= 0.0:
+                continue
+            combined = match_score * box.confidence
+            if combined > best_combined:
+                best_combined = combined
+                best_match_score = match_score
+                best = box
+
+        if best is None or best_combined < self._min_confidence:
+            return LocalOCRResult(
+                success=False,
+                error=f"No confident local match for '{query}' (best={best_combined:.2f})",
+            )
+
+        return LocalOCRResult(
+            success=True,
+            x=best.x,
+            y=best.y,
+            confidence=round(best_combined, 4),
+            matched_text=best.text,
+        )
+
+    @staticmethod
+    def extract_query_from_prompt(prompt: str) -> Optional[str]:
+        """
+        Best-effort extraction of a concrete text target from a natural-language
+        prompt, so prompts like:  Find the "Submit" button  →  Submit
+
+        Returns the quoted phrase when present, else None (meaning: this prompt
+        is not obviously a simple text target — let the LLM handle it).
+        """
+        if not prompt:
+            return None
+        # Prefer an explicitly quoted phrase (single, double, or smart quotes).
+        quoted = re.search(r"[\"'‘’“”]([^\"'‘’“”]{1,60})[\"'‘’“”]", prompt)
+        if quoted:
+            candidate = quoted.group(1).strip()
+            return candidate or None
+        return None

--- a/packages/python-core/src/vision/test_local_ocr_service.py
+++ b/packages/python-core/src/vision/test_local_ocr_service.py
@@ -1,0 +1,306 @@
+"""
+Tests for the Local OCR Service (token-saving text fallback).
+
+These tests do NOT require the Tesseract binary to be installed: the pure
+matching/normalization helpers are tested directly, and engine-dependent paths
+are tested by injecting a fake OCR engine / mocking pytesseract.
+
+Requirements: token optimization for ai-vision-capture (local text fallback).
+"""
+
+import asyncio
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from .local_ocr_service import (
+    LocalOCRService,
+    LocalOCRResult,
+    OCRMatch,
+    normalize_text,
+    text_match_score,
+)
+from .ai_vision_service import (
+    AIVisionService,
+    AIVisionRequest,
+    AIVisionResponse,
+)
+
+# NOTE: the vision package __init__ re-exports the `ai_vision_service` SINGLETON
+# under that name, which shadows the submodule. To patch module-level globals
+# (encode_image_base64, crop_to_roi) we must reach the real module object via
+# the class's __module__ entry in sys.modules.
+ai_vision_mod = sys.modules[AIVisionService.__module__]
+local_ocr_mod = sys.modules[LocalOCRService.__module__]
+
+
+# ============================================================================
+# Pure helpers (engine-independent)
+# ============================================================================
+
+class TestNormalizeText:
+    def test_lowercases_and_trims(self):
+        assert normalize_text("  Submit  ") == "submit"
+
+    def test_collapses_internal_whitespace(self):
+        assert normalize_text("Log\t In") == "log in"
+
+    def test_strips_surrounding_punctuation(self):
+        assert normalize_text("Submit:") == "submit"
+        assert normalize_text('"Login"') == "login"
+
+    def test_empty(self):
+        assert normalize_text("") == ""
+        assert normalize_text(None) == ""  # type: ignore[arg-type]
+
+
+class TestTextMatchScore:
+    def test_exact_match_is_one(self):
+        assert text_match_score("Submit", "submit") == 1.0
+
+    def test_exact_match_ignoring_punctuation(self):
+        assert text_match_score("Submit", "Submit:") == 1.0
+
+    def test_whole_word_containment(self):
+        # "OK" appears as a standalone word
+        assert text_match_score("OK", "Click OK now") == 0.9
+
+    def test_substring_containment_for_long_queries(self):
+        # "user" is a substring of "username" but not a standalone word -> 0.75
+        assert text_match_score("user", "username") == pytest.approx(0.75)
+
+    def test_whole_word_beats_substring(self):
+        # When the query appears as a whole word, that's the stronger 0.9 tier
+        assert text_match_score("Login", "Login Form") == 0.9
+
+    def test_no_match(self):
+        assert text_match_score("Submit", "Cancel") == 0.0
+
+    def test_empty_inputs(self):
+        assert text_match_score("", "anything") == 0.0
+        assert text_match_score("anything", "") == 0.0
+
+
+class TestExtractQueryFromPrompt:
+    def test_double_quotes(self):
+        assert LocalOCRService.extract_query_from_prompt('Find the "Submit" button') == "Submit"
+
+    def test_single_quotes(self):
+        assert LocalOCRService.extract_query_from_prompt("Click the 'Login' link") == "Login"
+
+    def test_smart_quotes(self):
+        assert LocalOCRService.extract_query_from_prompt("Tap the “Đăng nhập” button") == "Đăng nhập"
+
+    def test_no_quotes_returns_none(self):
+        # No concrete text target -> defer to LLM
+        assert LocalOCRService.extract_query_from_prompt("the blue button at top right") is None
+
+    def test_empty(self):
+        assert LocalOCRService.extract_query_from_prompt("") is None
+
+
+# ============================================================================
+# Graceful degradation when engine unavailable
+# ============================================================================
+
+class TestAvailability:
+    def test_unavailable_when_pytesseract_missing(self):
+        with patch.object(local_ocr_mod, "_pytesseract", None):
+            svc = LocalOCRService()
+            assert svc.is_available() is False
+            # locate_text must not raise; returns a clean failure
+            result = svc.locate_text("fake_base64", "Submit")
+            assert result.success is False
+            assert "not available" in (result.error or "").lower()
+
+    def test_unavailable_when_binary_missing(self):
+        fake = MagicMock()
+        fake.get_tesseract_version.side_effect = Exception("tesseract not found")
+        with patch.object(local_ocr_mod, "_pytesseract", fake):
+            svc = LocalOCRService()
+            assert svc.is_available() is False
+
+    def test_extract_text_boxes_returns_empty_when_unavailable(self):
+        with patch.object(local_ocr_mod, "_pytesseract", None):
+            svc = LocalOCRService()
+            assert svc.extract_text_boxes("fake_base64") == []
+
+
+# ============================================================================
+# locate_text with a fake engine (no real Tesseract)
+# ============================================================================
+
+def _make_service_with_boxes(boxes):
+    """Build a LocalOCRService whose engine is faked to return `boxes`."""
+    svc = LocalOCRService()
+    svc.is_available = MagicMock(return_value=True)  # type: ignore[method-assign]
+    svc.extract_text_boxes = MagicMock(return_value=boxes)  # type: ignore[method-assign]
+    return svc
+
+
+class TestLocateText:
+    def test_confident_exact_hit(self):
+        boxes = [
+            OCRMatch(text="Submit", x=100, y=50, confidence=0.95,
+                     left=80, top=40, width=40, height=20),
+            OCRMatch(text="Cancel", x=200, y=50, confidence=0.95,
+                     left=180, top=40, width=40, height=20),
+        ]
+        svc = _make_service_with_boxes(boxes)
+        result = svc.locate_text("img", "Submit")
+        assert result.success is True
+        assert (result.x, result.y) == (100, 50)
+        assert result.matched_text == "Submit"
+        assert result.confidence is not None and result.confidence >= 0.9
+
+    def test_low_ocr_confidence_defers_to_llm(self):
+        # Exact text but the OCR engine is unsure -> combined below threshold
+        boxes = [
+            OCRMatch(text="Submit", x=100, y=50, confidence=0.2,
+                     left=80, top=40, width=40, height=20),
+        ]
+        svc = _make_service_with_boxes(boxes)
+        result = svc.locate_text("img", "Submit")
+        assert result.success is False
+
+    def test_no_text_match_defers(self):
+        boxes = [
+            OCRMatch(text="Cancel", x=200, y=50, confidence=0.99,
+                     left=180, top=40, width=40, height=20),
+        ]
+        svc = _make_service_with_boxes(boxes)
+        result = svc.locate_text("img", "Submit")
+        assert result.success is False
+
+    def test_picks_highest_combined_confidence(self):
+        boxes = [
+            OCRMatch(text="Login", x=10, y=10, confidence=0.6,
+                     left=0, top=0, width=20, height=20),
+            OCRMatch(text="Login", x=300, y=300, confidence=0.99,
+                     left=290, top=290, width=20, height=20),
+        ]
+        svc = _make_service_with_boxes(boxes)
+        result = svc.locate_text("img", "Login")
+        assert result.success is True
+        assert (result.x, result.y) == (300, 300)
+
+    def test_empty_query(self):
+        svc = _make_service_with_boxes([])
+        result = svc.locate_text("img", "  ")
+        assert result.success is False
+
+
+# ============================================================================
+# AIVisionService integration: local OCR avoids the LLM (token savings)
+# ============================================================================
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestAIVisionServiceLocalOCRIntegration:
+    def _service_with_local_hit(self, x=120, y=60):
+        """AIVisionService whose injected local OCR always returns a hit."""
+        local = MagicMock(spec=LocalOCRService)
+        local.is_available.return_value = True
+        # extract_query_from_prompt is a staticmethod on the class; patch on class
+        local.locate_text.return_value = LocalOCRResult(
+            success=True, x=x, y=y, confidence=0.92, matched_text="Submit"
+        )
+        svc = AIVisionService(local_ocr=local)
+        return svc, local
+
+    @patch.object(ai_vision_mod, "encode_image_base64", side_effect=lambda s: s)
+    def test_local_hit_skips_llm(self, _enc):
+        svc, local = self._service_with_local_hit()
+        _run(svc.initialize("fake-key"))
+        # Guard: the LLM call must never run on a local hit.
+        svc._call_gemini_vision_api = MagicMock(
+            side_effect=AssertionError("LLM must not be called on local OCR hit")
+        )
+        req = AIVisionRequest(screenshot="img-b64", prompt='Find the "Submit" button')
+        resp = _run(svc.analyze(req))
+        assert resp.success is True
+        assert (resp.x, resp.y) == (120, 60)
+        assert svc.local_ocr_hits == 1
+        assert svc.llm_calls == 0
+
+    @patch.object(ai_vision_mod, "encode_image_base64", side_effect=lambda s: s)
+    def test_falls_back_to_llm_when_local_misses(self, _enc):
+        local = MagicMock(spec=LocalOCRService)
+        local.is_available.return_value = True
+        local.locate_text.return_value = LocalOCRResult(success=False, error="no match")
+        svc = AIVisionService(local_ocr=local)
+        _run(svc.initialize("fake-key"))
+
+        async def fake_llm(*args, **kwargs):
+            return AIVisionResponse(success=True, x=5, y=5, confidence=0.8)
+
+        svc._call_gemini_vision_api = MagicMock(side_effect=fake_llm)
+        req = AIVisionRequest(screenshot="img-b64", prompt='Find the "Submit" button')
+        resp = _run(svc.analyze(req))
+        assert resp.success is True
+        assert (resp.x, resp.y) == (5, 5)
+        assert svc.local_ocr_hits == 0
+        assert svc.llm_calls == 1
+
+    @patch.object(ai_vision_mod, "encode_image_base64", side_effect=lambda s: s)
+    def test_reference_images_skip_local_ocr(self, _enc):
+        # Reference images imply visual matching -> OCR is bypassed entirely.
+        svc, local = self._service_with_local_hit()
+        _run(svc.initialize("fake-key"))
+
+        async def fake_llm(*args, **kwargs):
+            return AIVisionResponse(success=True, x=9, y=9, confidence=0.8)
+
+        svc._call_gemini_vision_api = MagicMock(side_effect=fake_llm)
+        req = AIVisionRequest(
+            screenshot="img-b64",
+            prompt='Find the "Submit" button',
+            reference_images=["ref-b64"],
+        )
+        resp = _run(svc.analyze(req))
+        assert resp.success is True
+        assert (resp.x, resp.y) == (9, 9)
+        local.locate_text.assert_not_called()
+        assert svc.llm_calls == 1
+
+    @patch.object(ai_vision_mod, "encode_image_base64", side_effect=lambda s: s)
+    def test_disabled_local_ocr_always_uses_llm(self, _enc):
+        svc, local = self._service_with_local_hit()
+        svc.set_local_ocr_enabled(False)
+        _run(svc.initialize("fake-key"))
+
+        async def fake_llm(*args, **kwargs):
+            return AIVisionResponse(success=True, x=1, y=2, confidence=0.8)
+
+        svc._call_gemini_vision_api = MagicMock(side_effect=fake_llm)
+        req = AIVisionRequest(screenshot="img-b64", prompt='Find the "Submit" button')
+        resp = _run(svc.analyze(req))
+        assert (resp.x, resp.y) == (1, 2)
+        local.locate_text.assert_not_called()
+        assert svc.llm_calls == 1
+
+    @patch.object(ai_vision_mod, "encode_image_base64", side_effect=lambda s: s)
+    def test_local_ocr_applies_roi_offset(self, _enc):
+        # When ROI cropping is used, the local hit coords must be offset back
+        # into full-screen space.
+        local = MagicMock(spec=LocalOCRService)
+        local.is_available.return_value = True
+        local.locate_text.return_value = LocalOCRResult(
+            success=True, x=10, y=20, confidence=0.9, matched_text="Submit"
+        )
+        svc = AIVisionService(local_ocr=local)
+        _run(svc.initialize("fake-key"))
+
+        from .ai_vision_service import VisionROI
+        with patch.object(ai_vision_mod, "crop_to_roi", side_effect=lambda b, *a: b):
+            req = AIVisionRequest(
+                screenshot="img-b64",
+                prompt='Find the "Submit" button',
+                roi=VisionROI(x=100, y=200, width=50, height=50),
+            )
+            resp = _run(svc.analyze(req))
+        assert resp.success is True
+        assert (resp.x, resp.y) == (110, 220)  # 10+100, 20+200

--- a/packages/rust-core/src/platform/macos.rs
+++ b/packages/rust-core/src/platform/macos.rs
@@ -206,13 +206,15 @@ impl MacOSAutomation {
     #[cfg(target_os = "macos")]
     fn check_accessibility_permissions(&self) -> Result<bool> {
         if let Some(logger) = get_logger() {
+            let mut metadata = HashMap::new();
+            metadata.insert("platform".to_string(), json!("macos"));
             logger.log_operation(
                 LogLevel::Info,
                 CoreType::Rust,
                 OperationType::Playback,
                 "permission_check".to_string(),
                 "Checking macOS accessibility permissions".to_string(),
-                None,
+                Some(metadata),
             );
         }
 
@@ -229,7 +231,8 @@ impl MacOSAutomation {
         if let Some(logger) = get_logger() {
             let mut metadata = HashMap::new();
             metadata.insert("has_permissions".to_string(), json!(trusted));
-            
+            metadata.insert("platform".to_string(), json!("macos"));
+
             logger.log_operation(
                 if trusted { LogLevel::Info } else { LogLevel::Warn },
                 CoreType::Rust,
@@ -334,23 +337,22 @@ impl PlatformAutomation for MacOSAutomation {
     }
     
     fn check_permissions(&self) -> Result<bool> {
-        // Check if we have accessibility permissions
+        // Report permission STATUS as a boolean. A status query must not fail
+        // with an error just because permission is currently absent — that
+        // conflates "could not check" with "permission denied" and matches the
+        // Linux/Windows implementations which return Ok(false)/Ok(true).
+        //
+        // Callers (player.rs / recorder.rs) act on Ok(false) by invoking
+        // request_permissions(), which surfaces the detailed instructions and
+        // the System Preferences deep link.
         let has_permissions = self.check_accessibility_permissions()?;
-        
+
         if !has_permissions {
+            // Still log the denial with actionable instructions for diagnostics.
             self.log_permission_denial();
-            
-            return Err(AutomationError::PermissionDenied {
-                operation: format!(
-                    "macOS Accessibility permissions required.\n\n{}\n\n\
-                    You can also open System Preferences directly using this link:\n\
-                    x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
-                    self.get_permission_instructions()
-                ),
-            });
         }
-        
-        Ok(true)
+
+        Ok(has_permissions)
     }
     
     fn request_permissions(&self) -> Result<bool> {
@@ -363,8 +365,13 @@ impl PlatformAutomation for MacOSAutomation {
         if !has_permissions {
             if let Some(logger) = get_logger() {
                 let mut metadata = HashMap::new();
+                // Include platform metadata so diagnostics/consumers can attribute
+                // the message to the correct OS (kept consistent with
+                // log_permission_denial).
+                metadata.insert("platform".to_string(), json!("macos"));
+                metadata.insert("required_permission".to_string(), json!("Accessibility"));
                 metadata.insert("instructions".to_string(), json!(self.get_permission_instructions()));
-                
+
                 logger.log_operation(
                     LogLevel::Warn,
                     CoreType::Rust,

--- a/packages/rust-core/src/preferences_property_tests.rs
+++ b/packages/rust-core/src/preferences_property_tests.rs
@@ -747,13 +747,14 @@ mod unit_tests {
     fn test_property_test_setup() {
         // Verify that our test setup works correctly
         let (manager, _temp_dir) = create_temp_preference_manager();
-        
-        // Default should be Python core
-        assert_eq!(manager.get_preferred_core(), CoreType::Python);
-        
+
+        // Default is the Rust core (see CoreType::default in preferences.rs —
+        // chosen for better performance on the macOS automation path).
+        assert_eq!(manager.get_preferred_core(), CoreType::Rust);
+
         // Should be able to create multiple managers
         let (manager2, _temp_dir2) = create_temp_preference_manager();
-        assert_eq!(manager2.get_preferred_core(), CoreType::Python);
+        assert_eq!(manager2.get_preferred_core(), CoreType::Rust);
     }
     
     #[test]

--- a/scripts/run-macos-automation-tests.sh
+++ b/scripts/run-macos-automation-tests.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Self-running test + demo harness for the GeniusQA macOS automation version.
+#
+# Runs the green, automation-core test suites and the end-to-end self-running
+# demo. Intentionally scopes to the subsystems that power the macOS automation
+# loop (OCR / vision / playback / scripting / permissions) — it does NOT run the
+# desktop "react" (jsdom UI) project or the rust "visual_testing" module, both of
+# which have known pre-existing failures tracked separately.
+#
+# Usage:
+#   ./scripts/run-macos-automation-tests.sh            # tests + safe demo
+#   ./scripts/run-macos-automation-tests.sh --no-rust  # skip slow rust suite
+#   ./scripts/run-macos-automation-tests.sh --demo-only
+#
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUN_RUST=1
+DEMO_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --no-rust)   RUN_RUST=0 ;;
+    --demo-only) DEMO_ONLY=1 ;;
+    *) echo "Unknown arg: $arg"; exit 2 ;;
+  esac
+done
+
+# Ensure Node 22 for the desktop jest suites (machine default may be older).
+if [ -s "$HOME/.nvm/nvm.sh" ]; then
+  # shellcheck disable=SC1091
+  . "$HOME/.nvm/nvm.sh"
+  nvm use 22 >/dev/null 2>&1 || true
+fi
+
+fail=0
+section() { printf '\n========== %s ==========\n' "$1"; }
+
+if [ "$DEMO_ONLY" -eq 0 ]; then
+  section "Python core (vision / OCR / player / recorder / storage)"
+  ( cd "$ROOT/packages/python-core" && python3 -m pytest src/ -q -p no:cacheprovider ) || fail=1
+
+  section "Desktop services + utils (automation services)"
+  ( cd "$ROOT/packages/desktop" && npx jest --selectProjects services utils ) || fail=1
+
+  if [ "$RUN_RUST" -eq 1 ]; then
+    section "Rust core (playback / permissions / preferences / integration)"
+    # Exclude the visual_testing module (tracked separately).
+    ( cd "$ROOT/packages/rust-core" && cargo test --lib -- --skip visual_testing ) || fail=1
+  fi
+fi
+
+section "End-to-end self-running macOS automation demo (safe mode)"
+( cd "$ROOT/packages/python-core" && python3 examples/self_running_macos_demo.py ) || fail=1
+
+section "Result"
+if [ "$fail" -eq 0 ]; then
+  echo "ALL AUTOMATION-CORE CHECKS PASSED"
+else
+  echo "SOME CHECKS FAILED (exit 1)"
+fi
+exit "$fail"


### PR DESCRIPTION
## What & why

Makes the **macOS automation version self-running and green**, and adds a **zero-token local-OCR fast path** for text targets so we stop spending LLM tokens on plain labels.

## Bug fixes — automation-core test suites now green

- **`firebaseService.test.ts`** — was a stale React-Native test (mocked `@react-native-firebase/*`, wrong env mock path) that couldn't run against the current Firebase **Web SDK / Tauri** service. Rewritten to the actual API surface.
- **`ipcBridgeService.test.ts`** — 3 error tests didn't mock the `getCoreStatus()` pre-call that `startPlayback()` makes, so the rejection was swallowed. Added the success mock so errors propagate.
- **`aiScriptPlaybackCompatibility.property.test.ts`** — root cause: `fc.assert(fc.asyncProperty(...))` was **not awaited**, so async properties ran past teardown ("Cannot log after tests are done"), floated rejections, and crashed the jest worker. Made the `it()` callbacks `async`/`await` and build a fresh, isolated `PlaybackService` per property run to kill cross-run state leaks.
- **rust `macos::check_permissions()`** — now returns `Ok(false)` when Accessibility is absent (consistent with Linux/Windows) instead of `Err`, which re-activates the graceful `request_permissions()` retry path in `player.rs`/`recorder.rs` (previously dead code on macOS). Permission logs now carry `platform` metadata.
- **rust preferences test** — default core is **Rust** (per `CoreType::default`); updated the stale assertion expecting Python.

## Feature — local OCR token optimization

- `vision/local_ocr_service.py`: locate on-screen text locally with Tesseract (**0 token, offline**). `AIVisionService.analyze()` tries this before the Gemini LLM for quoted text targets; reference-image requests skip it. **Optional dependency** with graceful degradation; telemetry via `local_ocr_hits` / `llm_calls`.
- Formal spec at `.kiro/specs/local-ocr-token-optimization/` (requirements + design + tasks) and an OCR fast-path section added to `ai-vision-capture/design.md`.

## Self-running E2E on macOS

- `examples/self_running_macos_demo.py`: full loop **screenshot → OCR/scan text → write script → execute (dry-run) → LLM-coordinate fallback → token accounting**, degrading gracefully when Screen Recording permission is missing.
- `src/test_self_running_macos_e2e.py`: automated counterpart (3 tests).
- `scripts/run-macos-automation-tests.sh`: one-command harness.

## Test status

| Suite | Result |
|---|---|
| Python core | 333 pass (29 OCR + 3 E2E new) |
| Desktop services + utils | 514 pass / 30 suites |
| Rust core (excl. visual_testing) | 240 pass, 0 fail (369 lib total) |
| E2E demo | located "Submit", **0 token**, exit 0 |

## Reviewer notes

- **Out of scope (pre-existing failures, tracked separately):** the desktop `react` (jsdom UI) project has ~237 failures from stale RN mocks + a changed `ipcBridgeService` API; rust `visual_testing` has 27 failures (real ROI/report bugs + env-sensitive benchmarks). Neither is touched here.
- A few staged files (`playbackService.ts`, `UnifiedScriptManager.tsx`, `scriptStorageService.ts`, and several property tests) were already in the working tree at session start and are part of the same in-progress automation work.
- `.gitignore` now ignores the whole `packages/rust-core/target/` build dir.
- `pytesseract` added to `requirements.txt` as an **optional** dep (needs the `tesseract` binary; `brew install tesseract`).