### PR TITLE
chore(release): bump version to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geniusqa",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geniusqa/desktop",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "GeniusQA desktop application using React Native/Tauri for Windows and macOS",
   "private": true,
   "main": "dist/index.js",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geniusqa-desktop"
-version = "1.0.0"
+version = "1.1.1"
 description = "GeniusQA Desktop - System automation and QA platform"
 authors = ["GeniusQA Team"]
 license = ""

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "GeniusQA Desktop",
-    "version": "1.0.0"
+    "version": "1.1.1"
   },
   "tauri": {
     "allowlist": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geniusqa/web",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "GeniusQA web platform for authentication and dashboard",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## What

Bumps the workspace and desktop app version to `1.1.1` ahead of the next release.

## Why

`packages/desktop/src-tauri/tauri.conf.json` and `packages/desktop/src-tauri/Cargo.toml` were still pinned at `1.0.0`, out of sync with the root `package.json` / `packages/web/package.json` / `packages/desktop/package.json` (all `1.1.0`) and the last published tag `v1.1.0`. That drift meant the built desktop app was reporting the wrong version number.

This PR syncs all five version references to `1.1.1` so the next release is internally consistent.

## Files changed

- `package.json`
- `packages/desktop/package.json`
- `packages/web/package.json`
- `packages/desktop/src-tauri/Cargo.toml`
- `packages/desktop/src-tauri/tauri.conf.json`

## Notes for reviewers

- No functional code changes — version bump only.
- After merging to `main`, tag `v1.1.1` and push it to trigger `.github/workflows/release.yml`, which creates the GitHub Release and builds the Tauri desktop app for macOS/Linux/Windows.